### PR TITLE
Add Burnd to Cost Optimization

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -501,6 +501,13 @@ Utilities and tools to enhance your Claude workflow.
 
 ### Cost Optimization
 
+- [garvitsurana/burnd](https://github.com/garvitsurana/burnd) ![Stars](https://img.shields.io/github/stars/garvitsurana/burnd?style=flat-square)
+  - Local-first CLI that reads `.claude/projects/*.jsonl` session files
+  - Finds cost leaks: retry storms, tool overuse, repeated reads, long bash output
+  - Flags tired-coding hours and project-cost outliers
+  - Runs entirely offline, no data leaves your machine
+  - Free core + optional Pro detectors (`npx getburnd`)
+
 - [Sagargupta16/claude-cost-optimizer](https://github.com/Sagargupta16/claude-cost-optimizer) ![Stars](https://img.shields.io/github/stars/Sagargupta16/claude-cost-optimizer?style=flat-square)
   - Save 30-60% on Claude API costs
   - 6 guides and 15 optimization strategies


### PR DESCRIPTION
Adding **Burnd** to the Cost Optimization section. It sits alongside `claude-cost-optimizer` and `claude-token-optimizer`, but takes a different angle: instead of optimization guides or token compression, Burnd analyzes your actual `.claude/projects/*.jsonl` session files locally and surfaces specific leak patterns (retry storms, tool overuse, repeated reads, long bash output, tired-coding hours, project-cost outliers).

- Repo: https://github.com/garvitsurana/burnd
- Runs via `npx getburnd` — no install, no upload, nothing leaves the machine
- Site: https://getburnd.vercel.app

Free core with optional Pro detectors. MIT.