### PR TITLE
Add claude-code-slice-skills to Core Development Skills

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -160,6 +160,13 @@ Skills focused on software development, code quality, and engineering workflows.
   - CLI tool with full LLM usage guide
   - Works with Claude Code, Amp, and Codex
 
+- [arun-mosai/claude-code-slice-skills](https://github.com/arun-mosai/claude-code-slice-skills) ![Stars](https://img.shields.io/github/stars/arun-mosai/claude-code-slice-skills?style=flat-square)
+  - Three composable skills (`/slice`, `/slice-resume`, `/slice-build`) for vertical-slice feature development
+  - Turns a one-line feature idea into 11 validated design docs (persona, journey, UI, API, data, security, observability, AI, seed, tests, index)
+  - Then implements the slice as migrations, handlers, UI, events, and tests
+  - 12 validator sub-agents enforce specificity; atomic cycle commit; project-stage-calibrated ceremony
+  - Stack-neutral structure with TypeScript/Postgres/Zod/React defaults and a porting guide for Django/Rails/Go/Next.js
+
 ### Specialized Agents
 
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) ![Stars](https://img.shields.io/github/stars/VoltAgent/awesome-claude-code-subagents?style=flat-square)


### PR DESCRIPTION
Adds [**arun-mosai/claude-code-slice-skills**](https://github.com/arun-mosai/claude-code-slice-skills) to Core Development Skills.

### What it does

Three composable Claude Code skills that turn a one-line feature idea into a production vertical slice:

- `/slice` — produces 11 validated design docs (persona, journey, UI, API, data model, security, observability, AI surface, seed data, tests, index)
- `/slice-resume` — re-enters a paused slice from its `PROGRESS.md` checkpoint after `/clear`
- `/slice-build` — implements the slice as migrations + handlers + UI + events + tests with 7-step verification

### Why it might be interesting

- 12 validator sub-agents enforce specificity (no "Customer 1" seed rows; banned-phrase list kills marketing slop; every screen covers 7 canonical states)
- Atomic cycle commit — nothing commits mid-cycle; state lives in durable files that survive `/clear`
- Project-stage calibration — one set of skills, seven different ceremony bars based on a `CLAUDE.md` declaration (prototype → regulated-production)
- Blocker verification by Status + Resolution shape (works across any blocker-ID taxonomy)

### Stack

Ships with TypeScript + Postgres + Zod + React defaults. `PORTING.md` documents stack assumptions and port paths for Django / Rails / Go / Next.js. The skill structure (phases, validators, resolution loop, atomic commit) is stack-neutral.

MIT. Actively maintained. Thanks for considering!