### PR TITLE
Add claude-ecom to Domain-Specific Skills

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -323,6 +323,13 @@ Specialized skills for specific industries and use cases.
   - Quality gates and replication protocols
   - Extracted from production PhD course
 
+- [takechanman1228/claude-ecom](https://github.com/takechanman1228/claude-ecom) ![Stars](https://img.shields.io/github/stars/takechanman1228/claude-ecom?style=flat-square)
+  - Ecommerce business review skill for D2C stores
+  - Multi-horizon KPI decomposition across 30d/90d/365d
+  - ~30 automated health checks across revenue, customer, and product
+  - RFM cohorts and prioritized action plan with impact estimates
+  - Hybrid Python-backend + Claude-LLM architecture for deterministic KPIs
+
 ---
 
 ## Productivity Tools


### PR DESCRIPTION
Hi — adding `claude-ecom`, an ecommerce business-review skill, under **Domain-Specific Skills**.

**What it does**: Turns an order CSV into a structured monthly business review for D2C stores — multi-horizon KPI decomposition (30d/90d/365d), ~30 automated health checks across revenue / customer / product, RFM cohort analysis, and a prioritized action plan with estimated revenue impact per finding.

**Why Domain-Specific Skills**: It's a vertical-specific (ecommerce) analysis tool rather than general marketing copy or content generation, so it sits alongside existing entries like the game-studio and academic-research skills in this section better than under Marketing & Content.

**Links**:
- Repo: https://github.com/takechanman1228/claude-ecom
- License: MIT
- Latest release: v0.1.3
- Active: yes (recent commits)
- SKILL.md with YAML frontmatter, packaged for pip + Claude Code plugin marketplace

Happy to revise wording, placement, or category if you'd prefer it different.