### PR TITLE
✨ Add KubeStellar Console MCP server (kc-agent) to MCP Servers & Integrations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -446,6 +446,13 @@ Utilities and tools to enhance your Claude workflow.
   - Interactive process control and session management
   - Docker isolation for sandboxing
 
+- [kubestellar/console](https://github.com/kubestellar/console) ![Stars](https://img.shields.io/github/stars/kubestellar/console?style=flat-square)
+  - MCP server (`kc-agent`) bridging AI assistants to multi-cluster Kubernetes
+  - Manage workloads, pods, namespaces, and RBAC across clusters via natural language
+  - Built-in AI-powered dashboard with 250+ CNCF project integrations
+  - Works with Claude Code, Claude Desktop, and any MCP-compatible client
+  - Live demo: https://console.kubestellar.io
+
 ### API & Integration Tools
 
 - [router-for-me/CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) ![Stars](https://img.shields.io/github/stars/router-for-me/CLIProxyAPI?style=flat-square)


### PR DESCRIPTION
## Summary

[KubeStellar Console](https://github.com/kubestellar/console) includes **kc-agent**, an MCP server that bridges AI assistants like Claude Code and Claude Desktop to multi-cluster Kubernetes environments.

### What it does
- **MCP server** (`kc-agent`) enables natural language management of Kubernetes workloads across multiple clusters
- List/describe/manage pods, namespaces, deployments, services, and RBAC via Claude Code
- Built-in AI-powered dashboard with 250+ CNCF project integrations (Argo CD, Kyverno, Istio, Prometheus, etc.)
- Live demo: https://console.kubestellar.io

### Why it belongs here
This is an MCP server integration that enhances Claude Code's ability to manage cloud-native infrastructure directly — fitting exactly into the existing **MCP Servers & Integrations** section alongside tools like DesktopCommanderMCP.

### Checklist
- [x] Entry follows existing format with bullet-point description
- [x] GitHub repo is public and actively maintained (Apache-2.0 license)
- [x] Adds genuine value to the MCP Servers & Integrations section