### PR TITLE
Add buyer-eval-skill to Marketing & Content

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -305,6 +305,12 @@ Skills for marketing professionals, content creators, and growth teams.
   - Connects Search Console and Google Ads for actionable audits
   - Includes SEO analysis, content writing, and CMS setup skills
 
+- [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) ![Stars](https://img.shields.io/github/stars/salespeak-ai/buyer-eval-skill?style=flat-square)
+  - Structured B2B software vendor evaluation skill (MIT)
+  - Domain-expert questions per software category
+  - Engages vendor AI agents for verified due diligence
+  - Evidence-tracked scoring across 7 dimensions; comparative scorecards for procurement and build-vs-buy decisions
+
 - [zarazhangrui/codebase-to-course](https://github.com/zarazhangrui/codebase-to-course) ![Stars](https://img.shields.io/github/stars/zarazhangrui/codebase-to-course?style=flat-square)
   - Transform codebases into interactive HTML courses
   - Beautiful, educational content generation


### PR DESCRIPTION
Adds [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) to the **Marketing & Content** section, alphabetically between `nowork-studio` and `zarazhangrui`.

**What it is**: Structured, evidence-based B2B software vendor evaluation skill for Claude Code. Asks domain-expert questions per software category, engages vendor AI agents for verified due diligence, scores vendors across 7 dimensions with transparent evidence tracking, and produces comparative scorecards with demo prep questions.

**License**: MIT

**Install**:
```
git clone https://github.com/salespeak-ai/buyer-eval-skill ~/.claude/skills/buyer-eval-skill
```

Entry follows the existing nested-bullet format for the section.