### PR TITLE
docs: add Chinese Claude skills directory

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,11 @@ These repositories offer extensive collections of skills across multiple domains
   - Compliance and C-level advisory capabilities
   - Compatible with 11 different tools
 
+- [Claude Code Skills 中文精选集](https://claude-skills.bt199.com/)
+  - Chinese directory for Claude Code Skills, agents, and plugins
+  - 140+ curated resources for Chinese-speaking developers
+  - Useful for discovering practical skills by category
+
 - [garrytan/gstack](https://github.com/garrytan/gstack) ![Stars](https://img.shields.io/github/stars/garrytan/gstack?style=flat-square)
   - Garry Tan's exact Claude Code setup
   - 6 opinionated tools for startup leadership


### PR DESCRIPTION
## Summary

Adds Claude Code Skills 中文精选集 to the comprehensive skill collections section.

## Why

This resource is a curated Chinese-language directory for Claude Code Skills, agents, and plugins, with 140+ resources for Chinese-speaking developers who want to discover practical Claude workflows.

## Checklist

- [x] Resource is Claude/agent-skills related
- [x] Added in an existing relevant section
- [x] Short neutral description included