### PR TITLE
Add clockless-org/html-anything to Marketing & Content

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -326,6 +326,13 @@ Skills for marketing professionals, content creators, and growth teams.
   - Beautiful, educational content generation
   - Perfect for developer education and onboarding
 
+- [clockless-org/html-anything](https://github.com/clockless-org/html-anything) ![Stars](https://img.shields.io/github/stars/clockless-org/html-anything?style=flat-square)
+  - Turn any file, folder, URL, or service export into a polished single-file HTML page
+  - Auto picks one of 16 design systems (lesson lab, map atlas, timeline story, relationship rhythm, network map, dashboard, document review, terminal evidence, living essay, editorial carousel, paper trail, …)
+  - 34 source parsers — CSV, PDF, DOCX, JSON/JSONL, log, GPX/KML, WhatsApp/WeChat/Slack/Discord/Telegram, Amazon orders, Kindle highlights, Spotify, Apple Health, LinkedIn, Google Photos Takeout, vCard, Venmo/PayPal, browser history, …
+  - Self-contained — inline CSS/JS, no CDN, works offline; [22-demo live gallery](https://clockless-org.github.io/html-anything/examples/)
+  - Cross-agent — Claude Code, Codex, Cursor, Cline, Windsurf via `npx skills add clockless-org/html-anything`
+
 ---
 
 ## Domain-Specific Skills


### PR DESCRIPTION
Adds [`clockless-org/html-anything`](https://github.com/clockless-org/html-anything) next to `codebase-to-course` (sibling HTML-generator) in **Marketing & Content**.

> **Install once. Your agent answers as polished web pages whenever the content is actually a page, not a chat message.**

[`clockless-org/html-anything`](https://github.com/clockless-org/html-anything) turns rich agent answers — and any file, folder, URL, or service export — into a polished single-file HTML page. The skill auto-routes to one of 16 design systems (`teaching`, `relationship`, `timeline-story`, `map-atlas`, `network-map`, `document`, `dashboard`, `developer`, `living-essay`, `editorial-carousel`, `paper-trail`, `kinetic-scoreboard`, `soft-saas`, `digital-eguide`, `interactive-learning`, `default`), builds the HTML, verifies it in a browser, and hands it back. Short chats stay short.

**Install:** `npx skills add clockless-org/html-anything`

**Live gallery (22 demos):** https://clockless-org.github.io/html-anything/examples/

Sample outputs across the catalog:
- [Kindle highlights → `living-essay`](https://clockless-org.github.io/html-anything/examples/kindle-highlights/output.html)
- [Solar system brief → `teaching`](https://clockless-org.github.io/html-anything/examples/solar-system-studio/output.html)
- [WhatsApp / WeChat → `relationship`](https://clockless-org.github.io/html-anything/examples/wechat-couple/output.html)
- [Google Maps saved places → `map-atlas`](https://clockless-org.github.io/html-anything/examples/google-maps-stars/output.html)
- [LinkedIn connections → `network-map`](https://clockless-org.github.io/html-anything/examples/linkedin-connections/output.html)
- [PR review → `developer`](https://clockless-org.github.io/html-anything/examples/pr-review/output.html)

Apache 2.0 · cross-agent (Claude Code, Codex, Cursor, Cline, Windsurf via the open `npx skills` CLI) · already on [skills.sh](https://skills.sh/clockless-org/html-anything) · active maintenance (22 demos, 16 design systems, 34 source parsers).