### PR TITLE
Add: agency-os — Notion-based AI agency orchestration platform

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -252,6 +252,13 @@ Orchestrate multiple Claude agents to work together on complex tasks.
   - Evolving iterations for complex problem-solving
   - Self-improving agent patterns
 
+- [ratamaha-git/agency-os](https://github.com/ratamaha-git/agency-os) ![Stars](https://img.shields.io/github/stars/ratamaha-git/agency-os?style=flat-square)
+  - Run your work like an AI agency from a single Notion board
+  - Plans ideas into dependency-sequenced subtasks
+  - Dispatches each task to the right model (Haiku/Sonnet/Opus)
+  - Collects results back in Notion via MCP
+  - Pluggable to Claude Code, Cursor, Cline, or any MCP-compatible agent
+
 - [ruvnet/ruflo](https://github.com/ruvnet/ruflo) ![Stars](https://img.shields.io/github/stars/ruvnet/ruflo?style=flat-square)
   - Multi-agent swarm orchestration
   - Self-learning capabilities


### PR DESCRIPTION
## What this adds

**[agency-os](https://github.com/ratamaha-git/agency-os)** — Run your work like an AI agency from a single Notion board.

- Plans ideas into dependency-sequenced subtasks
- Dispatches each task to the right model (Haiku/Sonnet/Opus)
- Collects results back in Notion via MCP
- Pluggable to Claude Code, Cursor, Cline, or any MCP-compatible agent

Added to the **Multi-Agent Systems** → **Orchestration Platforms** section.

## Quality checklist
- [x] Open source (MIT licensed)
- [x] Publicly available on GitHub
- [x] Clear documentation and README
- [x] Actively maintained
- [x] Unique value: Notion-native control plane for AI agent orchestration with dependency-aware task scheduling