### PR TITLE
Add Agent FM

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -431,6 +431,10 @@ Utilities and tools to enhance your Claude workflow.
   - Agent Cockpit provides live iTerm2 orchestration and monitoring for active local agent sessions
   - Local-first transcript indexing with no telemetry
 
+- [agentfm-ai/agent-fm](https://github.com/agentfm-ai/agent-fm) ![Stars](https://img.shields.io/github/stars/agentfm-ai/agent-fm?style=flat-square)
+  - Local, open-source macOS app for listening to Claude Code and Codex agents as they work
+  - Global Mix across active sessions, blocker alerts, and BYOK Gemini/OpenAI narration
+
 ### Agent Harnesses & Meta-Tools
 
 - [code-yeongyu/oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) ![Stars](https://img.shields.io/github/stars/code-yeongyu/oh-my-openagent?style=flat-square)


### PR DESCRIPTION
Adds Agent FM to Desktop Applications & GUI Tools.

Agent FM is a local, open-source macOS companion for Claude Code and Codex sessions. It turns active sessions into narrated stations with Global Mix, blocker alerts, and BYOK Gemini/OpenAI narration.

I added it in this section because it provides a desktop GUI/background workflow for developers monitoring multiple local Claude Code sessions.
