### PR TITLE
Add pluginpool (10 productivity plugins, marketplace-installable)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -232,6 +232,12 @@ Skills focused on software development, code quality, and engineering workflows.
   - Compatible with Claude Code, Hermes Agent, OpenClaw, Kilocode, Copilot, and Mastra
   - Python-backed and MIT licensed
 
+- [mturac/pluginpool](https://github.com/mturac/pluginpool) ![Stars](https://img.shields.io/github/stars/mturac/pluginpool?style=flat-square)
+  - Ten focused Claude Code plugins for everyday developer productivity
+  - Includes **commit-narrator**, **pr-storyteller**, **test-gap**, **deps-doctor**, **env-lint**, **secret-guard**, **standup-gen**, **todo-harvest**, **flaky-detector**, **changelog-forge**
+  - 89 hermetic tests across the suite, Python standard library only at runtime
+  - Each plugin is a self-contained repo; install all via marketplace: `/plugin marketplace add mturac/pluginpool`. MIT licensed.
+
 ### Specialized Agents
 
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) ![Stars](https://img.shields.io/github/stars/VoltAgent/awesome-claude-code-subagents?style=flat-square)


### PR DESCRIPTION
Adds [mturac/pluginpool](https://github.com/mturac/pluginpool) — a Claude Code plugin marketplace with **ten focused developer productivity plugins**.

The 10 plugins:
1. **commit-narrator** — semantic commit message from staged diff
2. **pr-storyteller** — PR title + body + test plan from commits
3. **test-gap** — lines in diff lacking test coverage
4. **deps-doctor** — multi-ecosystem dependency audit (npm, pip, cargo, go)
5. **env-lint** — `.env` vs `.env.example` key parity (never prints values)
6. **secret-guard** — pre-commit secret scanner (pattern + entropy)
7. **standup-gen** — daily standup notes from git activity
8. **todo-harvest** — TODO/FIXME/HACK scan with git blame
9. **flaky-detector** — per-test flakiness % from N runs
10. **changelog-forge** — conventional commits → CHANGELOG + semver

89 hermetic tests across the suite, Python stdlib only at runtime, MIT. Install via marketplace or per-plugin clone.