### PR TITLE
Add Septim Agents Pack

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1359,3 +1359,5 @@ We welcome contributions! To add a skill or tool to this list:
 CC0 - Public Domain
 
 This curated list is maintained by the community for the community.
+
+- [Septim Agents Pack](https://septimlabs.com/agents?utm_source=awesome-list&utm_campaign=getbindu) - 15 named Claude Code sub-agents (Atlas, Luca, Canon, Ember, Tally, Nova, Ward, Mira, Juno, Pip, Hart, Halo, Beacon, Loom, Lynx) covering the full exec layer. Drops into `~/.claude/agents/`. Open-source sample at [github.com/septimlabs-code/septim-agents-pack-sample](https://github.com/septimlabs-code/septim-agents-pack-sample). $49 lifetime.


### PR DESCRIPTION
Adds Septim Agents Pack — 15 named Claude Code sub-agents covering the full exec layer for solo founders.

Open-source sample (MIT, one full agent file): https://github.com/septimlabs-code/septim-agents-pack-sample

Full paid pack: $49 lifetime at https://septimlabs.com/agents.