### PR TITLE
Add Remote OpenClaw Claude Skills to comprehensive collections

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,11 @@ These repositories offer extensive collections of skills across multiple domains
   - 140+ curated resources for Chinese-speaking developers
   - Useful for discovering practical skills by category
 
+- [Remote OpenClaw Claude Skills](https://www.remoteopenclaw.com/skills/claude)
+  - Claude-focused skills directory with reviewed GitHub listings, plugins, and agents
+  - Includes adjacent Codex, Hermes, and OpenClaw hubs for cross-agent comparison
+  - Useful when you want a Claude-specific entry point without losing the broader ecosystem view
+
 - [garrytan/gstack](https://github.com/garrytan/gstack) ![Stars](https://img.shields.io/github/stars/garrytan/gstack?style=flat-square)
   - Garry Tan's exact Claude Code setup
   - 6 opinionated tools for startup leadership


### PR DESCRIPTION
## Summary
- add Remote OpenClaw Claude Skills to the Comprehensive Skill Collections section

## Why this fits
That section already includes third-party directories alongside GitHub collections, including Claude Code Skills 中文精选集.

This addition uses the Claude-specific Remote OpenClaw URL rather than a generic homepage:
- https://www.remoteopenclaw.com/skills/claude

It stays Claude-focused while still giving readers a path into adjacent Codex, Hermes, and OpenClaw hubs when they need cross-agent comparison.