### PR TITLE
Add growth-retrospective-skill to Core Development Skills

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -251,6 +251,14 @@ Skills focused on software development, code quality, and engineering workflows.
   - Codebase architecture guidance
   - Git guardrails and issue triage
 
+- [YoungApple/growth-retrospective-skill](https://github.com/YoungApple/growth-retrospective-skill) ![Stars](https://img.shields.io/github/stars/YoungApple/growth-retrospective-skill?style=flat-square)
+  - Personal growth retrospectives ranked by decision-velocity signals from git + chat history
+  - Tracks 5 categories: domain knowledge, human skills, work habits, meta-cognition, productivity rhythm
+  - Graduation markers required on every Tier 1/2 item so items leave the list instead of piling up
+  - Step 0 Action Audit blocks new scans if prior level-up actions are untouched (anti-busywork forcing function)
+  - Cross-agent: same SKILL.md works in Claude Code, OpenAI Codex CLI, and Google Antigravity
+  - Try in 5 seconds: `git clone … && bash examples/demo-fixture/demo.sh` (no LLM needed)
+
 - [affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code) ![Stars](https://img.shields.io/github/stars/affaan-m/everything-claude-code?style=flat-square)
   - Agent harness performance optimization
   - Research-first development approach


### PR DESCRIPTION
## What

Adds [growth-retrospective-skill](https://github.com/YoungApple/growth-retrospective-skill) under **Core Development Skills**, placed after `mattpocock/skills` because both are skill-shaped developer workflow tools.

## Why this fits

It's a developer-growth skill: ranks personal gaps by **decision-velocity signals** extracted from `git log` + chat history, requires **graduation markers** (observable, bounded exit conditions) on every Tier 1/2 item, and includes a **Step 0 forcing function** that blocks new scans if prior level-up actions are untouched. The forcing function is the anti-busywork mechanism that distinguishes it from typical learning logs.

5 tracked categories: domain knowledge, human skills, work habits, meta-cognition, productivity rhythm. Most learning-log tools only cover category 1.

## Cross-agent

Same `SKILL.md` works in Claude Code, OpenAI Codex CLI, and Google Antigravity — uses the [agensi.io SKILL.md open standard](https://www.agensi.io/learn/skill-md-specification-open-standard).

## Try in 5 seconds without installing

```bash
git clone https://github.com/YoungApple/growth-retrospective-skill /tmp/grs && \
  bash /tmp/grs/examples/demo-fixture/demo.sh
```

Color-coded output of Step 0 Action Audit + signal extraction on a synthetic 14-day project. Pure shell, no LLM, no install.

## Quality

- **v0.2.0 released** with CI/Actions (validates SKILL.md frontmatter, required files, ShellCheck, Python syntax, 350-line budget on every push)
- **4 worked examples** in `examples/`: anonymized real project, dogfood audit on creator's own project (0/11 actions completed → forcing function correctly held off), Day-1 fresh-project handling, runnable demo fixture
- **Iteration-1 → iteration-2 evals** with 3 v1 defects fixed in v2 (language compliance, 5-category sweep, deliberate demotion)
- **EVAL-FRAMEWORK.md** explicitly documents which quality layers are validated (Output, Acceptance) vs which need real-user data (Outcome at 3-month horizon, Cost validated at ~\$0.30/incremental)
- **FAQ + SECURITY + CHANGELOG + CONTRIBUTING + bilingual README** (en + zh-CN)

## Honest notes

Brand new repo (created 2026-05-24, 1 star at submission time). I didn't find a stars threshold in the README — happy to wait if there's an unstated bar. The skill differs structurally from most entries in this section (single skill vs bundle), but `obra/superpowers` and `mattpocock/skills` both started small and the description format works fine for a single-purpose skill.

Companion PR: ComposioHQ/awesome-claude-skills#913.