### PR TITLE
feat: add longbridge/skills — 125+ financial market skills for HK/US/A-share/SG

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -780,6 +780,12 @@ Specialized skills for specific industries and use cases.
   - Aims to keep context and memory across iterations
   - Token-conscious by design
 
+- [longbridge/skills](https://github.com/longbridge/skills) ![Stars](https://img.shields.io/github/stars/longbridge/skills?style=flat-square)
+  - 125+ agent skills for Longbridge Securities — real-time quotes, charts, fundamentals, portfolio analytics, and valuation
+  - Covers HK, US, A-share (SH/SZ), and Singapore markets
+  - Trilingual support: Simplified Chinese, Traditional Chinese, and English
+  - Includes options (US/HK), warrants, DeFi yields, ETF analysis, and advanced portfolio tools
+
 ---
 
 ## Productivity Tools


### PR DESCRIPTION
## Summary

- Adds [longbridge/skills](https://github.com/longbridge/skills) to the **Domain-Specific Skills** section
- 125+ agent skills for Longbridge Securities covering real-time quotes, candlestick charts, fundamentals, portfolio analytics, options/warrants, ETF analysis, DCF valuation, and more
- Supports HK, US, A-share (SH/SZ), and Singapore equity markets plus crypto spot prices
- Trilingual: Simplified Chinese, Traditional Chinese, and English trigger keywords

## Why it fits

The collection targets financial market analysis — a distinct domain not currently represented in the list. The skills follow the [Agent Skills specification](https://agentskills.io/specification), install via `npx skills add longbridge/skills`, and are MIT-licensed.

## Test plan

- [ ] Link resolves to https://github.com/longbridge/skills
- [ ] Entry renders correctly in the Domain-Specific Skills section
- [ ] Stars badge displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)