### PR TITLE
Add: ndesv21/socialclaw — multi-platform social media scheduling and publishing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -617,6 +617,12 @@ Skills for marketing professionals, content creators, and growth teams.
   - Beautiful, educational content generation
   - Perfect for developer education and onboarding
 
+- [ndesv21/socialclaw](https://github.com/ndesv21/socialclaw) ![Stars](https://img.shields.io/github/stars/ndesv21/socialclaw?style=flat-square)
+  - Schedule and publish social media posts across 13 platforms via SocialClaw
+  - Supports X, LinkedIn (profile + page), Instagram, Facebook Pages, TikTok, YouTube, Reddit, WordPress, Pinterest
+  - One workspace API key (`SC_API_KEY`) for campaigns, media upload, and analytics
+  - Install: `npx skills add ndesv21/socialclaw`
+
 - [clockless-org/html-anything](https://github.com/clockless-org/html-anything) ![Stars](https://img.shields.io/github/stars/clockless-org/html-anything?style=flat-square)
   - Turn any file, folder, URL, or service export into a polished single-file HTML page
   - Auto picks one of 16 design systems (lesson lab, map atlas, timeline story, relationship rhythm, network map, dashboard, document review, terminal evidence, living essay, editorial carousel, paper trail, …)


### PR DESCRIPTION
## Summary

Adds [SocialClaw](https://github.com/ndesv21/socialclaw) to the **Marketing & Content** section.

SocialClaw is an agent-first social publishing skill that enables scheduling and publishing across 13 platforms through a single workspace API key.

**Supported platforms:** X, LinkedIn (profile + page), Instagram (Business + standalone), Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest

**Install:**
```bash
npx skills add ndesv21/socialclaw
```

Provider OAuth is handled in the SocialClaw dashboard — no per-provider credentials are ever exposed to the agent.

---
*Source: https://github.com/ndesv21/socialclaw | https://getsocialclaw.com*