### PR TITLE
Add huangji6693-max/claude-code-dna — behavioral OS for Claude Code agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -892,6 +892,13 @@ Utilities and tools to enhance your Claude workflow.
   - Rust-based binary
   - Reduces friction when running multiple coding agents on the same repo
 
+- [huangji6693-max/claude-code-dna](https://github.com/huangji6693-max/claude-code-dna) ![Stars](https://img.shields.io/github/stars/huangji6693-max/claude-code-dna?style=flat-square)
+  - Behavioral OS for Claude Code agents distilled from 11 deeply-read libraries (179 skills + 99 agents + Karpathy anti-patterns + memory research)
+  - 8 rule files codifying Karpathy's 4 laws plus 15 operating instincts (verification gate, TDD reflex, root cause before fix)
+  - Three-layer memory architecture inspired by mem0 v3 (ADD-only), langmem (3 types × 2 timings), and Microsoft GraphRAG (community-summary indexing)
+  - Portable Bash/Python tooling: `memory-health.sh`, `memory-search.sh` (BM25-style local retrieval), `skill-spec-audit.sh` (agentskills.io compliance — 168 PASS / 23 WARN / 3 FAIL on 194 community skills), and `dna-doctor.sh` (single-command health check)
+  - Works across Claude Code, Cursor, Codex CLI, Gemini CLI, Aider, and Continue.dev — rules are model-agnostic markdown
+
 ### Memory & Context Management
 
 - [sunnja69/akephalos](https://github.com/sunnja69/akephalos) ![Stars](https://img.shields.io/github/stars/sunnja69/akephalos?style=flat-square)


### PR DESCRIPTION
Adds [huangji6693-max/claude-code-dna](https://github.com/huangji6693-max/claude-code-dna) under **Agent Harnesses & Meta-Tools** — a behavioral OS for Claude Code agents distilled from 11 deeply-read libraries (179 skills + 99 agents + Karpathy anti-patterns + memory research).

**What it contains:**

- **Rules layer** — 8 markdown files codifying Karpathy's 4 laws (Think → Simplicity → Surgical → Goal-driven) plus 15 operating instincts (verification gate before "done", TDD reflex, root cause before fix, no refactor-while-fixing)
- **Memory layer** — three-layer architecture inspired by mem0 v3 (ADD-only writes), langmem (3 types × 2 timings: semantic / episodic / procedural), and Microsoft GraphRAG (community-summary indexing). MEMORY.md as load-bearing index; per-project scope isolation via subdirectories
- **Audit tooling** — 4 portable scripts:
  - `memory-health.sh` (size / broken links / orphans / stale / frontmatter checks)
  - `memory-search.sh` (BM25-style local retrieval, no vector DB at this scale)
  - `skill-spec-audit.sh` (agentskills.io compliance — currently 168 PASS / 23 WARN / 3 FAIL on 194 community skills)
  - `dna-doctor.sh` (17 checks in <1s, wired into CI; `--installed` mode audits live `~/.claude/`)
- **Curated catalog** of 194 skills + 99 agents with category, trigger keyword, and spec-compliance score
- **Cross-harness** — works in Cursor, Codex CLI, Gemini CLI, Aider, Continue.dev (rules are model-agnostic markdown; concrete copy-paste setup in `examples/cross-harness-compatibility.md`)

**License**: MIT. **Status**: v0.1.4. **Telemetry**: none (zero phone-home).

Section chosen: **Agent Harnesses & Meta-Tools** — closest neighbor is `intellectronica/ruler` (also applies rules across coding agents). Memory architecture is a major feature but the project is broader than just memory, so meta-tools is the better primary home.