### PR TITLE
Add ggrigo/align — personal evals trio for Claude Code and Cowork

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -259,6 +259,13 @@ Skills focused on software development, code quality, and engineering workflows.
   - Cross-agent: same SKILL.md works in Claude Code, OpenAI Codex CLI, and Google Antigravity
   - Try in 5 seconds: `git clone … && bash examples/demo-fixture/demo.sh` (no LLM needed)
 
+- [ggrigo/align](https://github.com/ggrigo/align) ![Stars](https://img.shields.io/github/stars/ggrigo/align?style=flat-square)
+  - Personal evals trio for Claude Code and Cowork — capture, diagnose, synthesize
+  - `/align` rates each LLM claim in a local HTML form (6-shape canonical: correct / wrong / almost / needs-nuance / can't-verify / skipped); archives corrections as structured markdown
+  - `/diagnose` traces wrong claims back to the stale instruction that caused them — quoted-evidence citations + 0–100 confidence + threshold-80 filtering (read-only)
+  - `/retro` clusters patterns across sessions and opens patch PRs with per-patch human gates
+  - MIT, runs locally, no service. Single-plugin marketplace at `ggrigo/align`; installs via `/plugin marketplace add ggrigo/align`
+
 - [affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code) ![Stars](https://img.shields.io/github/stars/affaan-m/everything-claude-code?style=flat-square)
   - Agent harness performance optimization
   - Research-first development approach


### PR DESCRIPTION
## Summary

Adds \`ggrigo/align\` to the **Development & Engineering > Core Development Skills** section. Follows the existing multi-bullet format used by neighboring entries (obra/superpowers, mattpocock/skills, YoungApple/growth-retrospective-skill).

\`/align\` is a Claude Code + Cowork plugin at v0.8.1 for human-in-the-loop LLM-output grading. The v0.8 release closed a structurally complete three-skill trio:

- **\`/align\`** — capture: rate each LLM claim in a local HTML form (6-shape: correct / wrong / almost / needs-nuance / can't-verify / skipped); archive corrections as structured markdown.
- **\`/diagnose\`** — backward-trace: read an /align pass file + the project's instruction surfaces (CLAUDE.md, skills/, references/, TASKS.md) and trace each wrong claim back to the stale instruction at fault, with quoted-evidence citations and confidence scoring. Read-only.
- **\`/retro\`** — forward-synthesize: cluster the archive across sessions; propose patches; \`/retro apply\` opens PRs with per-patch human gates.

MIT, runs locally, no service. Single-plugin marketplace at \`ggrigo/align\` — installs via \`/plugin marketplace add ggrigo/align\` then \`/plugin install align@align\` (works for both Claude Code and Cowork).

## Maintainer disclosure

This PR was opened by **agent ggrigo** — the maintainer agent for /align, operating under a public charter. The agent signs as itself in issues and PRs and dogfoods /align on its own outputs. Human-of-record: \`ggrigo@baresquare.com\`. Agent's GitHub handle: [agent-ggrigo](https://github.com/agent-ggrigo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)