### PR TITLE
Add CLAUDE.md Auditor (Development & Engineering)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -412,6 +412,12 @@ Skills focused on software development, code quality, and engineering workflows.
   - Embeds Claude Code into the Neovim workflow
   - Lua-based; maintained by Coder
 
+- [infai-tech/claudemd-auditor-skill](https://github.com/infai-tech/claudemd-auditor-skill) ![Stars](https://img.shields.io/github/stars/infai-tech/claudemd-auditor-skill?style=flat-square)
+  - Calibrated 0–100 audit of `CLAUDE.md` files on six axes (Specificity, Coverage, Brevity, Currency, Quirks captured, Tone fit)
+  - v1.0 matches human baselines at Δ=0 across a 6-case corpus spanning 14–78 points; adversarial corpus exercises three error codes (`too_short`, `not_a_claudemd`, `too_long`)
+  - Returns paste-ready Top-3 improvements with concrete markdown snippets
+  - Drop-in `~/.claude/skills/claudemd-auditor/` install; MIT licensed; no external dependencies
+
 ---
 
 ## Multi-Agent Systems


### PR DESCRIPTION
Adds the **CLAUDE.md Auditor** skill to the Development & Engineering section.

## What it does

Calibrated 0–100 scoring for `CLAUDE.md` files on six axes (Specificity, Coverage, Brevity, Currency, Quirks captured, Tone fit). Returns paste-ready Top-3 improvements. Auto-targets `./CLAUDE.md`, falls back to `~/.claude/CLAUDE.md`, or takes a path / GitHub URL.

## Why it fits

- **Calibrated, not vibes:** v1.0 matches human baselines at Δ=0 across a 6-case corpus spanning 14–78 points. Adversarial-input corpus exercises all three error codes (`too_short`, `not_a_claudemd`, `too_long`).
- **Drop-in install:** clone + copy the `claudemd-auditor/` folder into `~/.claude/skills/`. Restart Claude Code. Ask "audit my CLAUDE.md."
- **MIT licensed**, self-contained SKILL.md + locator playbook, no external dependencies, no telemetry.

## Repo

https://github.com/infai-tech/claudemd-auditor-skill

Thanks for maintaining this list.