### PR TITLE
Add should-i-care (CVE applicability triage) to Security

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -562,6 +562,11 @@ n- [GiulioDER/cca-audit](https://github.com/GiulioDER/cca-audit) ![Stars](https:
   - Deduplicates findings, auto-fixes P1+P2, re-verifies tests, architect review gate
   - Three variants: Claude Code, Codex CLI, OpenRouter Python CLI
 
+- [moltenbit/should-i-care](https://github.com/moltenbit/should-i-care) ![Stars](https://img.shields.io/github/stars/moltenbit/should-i-care?style=flat-square)
+  - Single-CVE applicability triage: does this CVE actually affect your environment
+  - Reasons about exploitation conditions against a self-maintained environment profile, every verdict cited to its source
+  - Markdown-driven; built and tested on Claude Code and Codex
+
 - [wrsmith108/varlock-claude-skill](https://github.com/wrsmith108/varlock-claude-skill) ![Stars](https://img.shields.io/github/stars/wrsmith108/varlock-claude-skill?style=flat-square)
   - Secure environment variable management
   - Ensures secrets never appear in sessions, terminals, logs, or git


### PR DESCRIPTION
Adds should-i-care, a skill for single-CVE applicability triage.

It answers "does this CVE actually affect my environment" by reasoning about
a CVE's exploitation conditions against a self-maintained environment profile,
rather than just matching product/version. Every verdict exposes its reasoning
chain and cites each condition to its source (CVE.org/MITRE, vendor advisories,
established research), with a full audit of what was consulted.

Built and tested on Claude Code and Codex; follows the open agent-skills
standard, so standard-compatible elsewhere (untested on other agents).
MIT licensed, keyless, no bundled scripts.

One item, added to the Security section.