### PR TITLE
Add: AutomateLab-tech/publishing-skills

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1226,6 +1226,12 @@ Utilities and tools to enhance your Claude workflow.
   - JavaScript implementation; MIT licensed
   - Project site at getcaveman.dev
 
+- [AutomateLab-tech/publishing-skills](https://github.com/AutomateLab-tech/publishing-skills) ![Stars](https://img.shields.io/github/stars/AutomateLab-tech/publishing-skills?style=flat-square)
+  - Four composable skills for end-to-end SEO blog publishing
+  - Topic research, writing pipeline, SVG figures, editorial calendar
+  - Platform-agnostic: Ghost, WordPress, or any static site
+  - MIT-0 licensed; installs into Claude Code, Cursor, Codex, and 50+ runtimes
+
 ---
 
 ## Learning & Documentation


### PR DESCRIPTION
Adds [publishing-skills](https://github.com/AutomateLab-tech/publishing-skills) to the **Marketing & Content** section.

Four composable Claude Code skills that turn an AI agent into a long-tail SEO publishing pipeline:

- **`blog-topic-research`** — mines real user demand (PAA, Reddit, Stack Overflow, GitHub issues) before drafting; every accepted topic ships with citable evidence URLs
- **`seo-blog-writer`** — end-to-end pipeline: classify → research → draft clean HTML → scrub LLM tells → AI-SEO audit → publish; adds FAQPage + HowTo JSON-LD for citation extractability
- **`blog-figure-svg`** — accessible SVG figures (flow, comparison bars, OG feature cards) rasterized to compressed PNG
- **`blog-editorial-calendar`** — keeps a backlog, picks the next topic to balance cluster weights, schedules into a rolling cadence, auto-refills via topic research

Platform-agnostic: Ghost Admin API, WordPress REST, and static-site adapters ship out of the box.

- MIT-0 (public domain equivalent), no attribution required
- Installs into Claude Code, Cursor, Codex, Gemini CLI, and 50+ runtimes via `npx skills add AutomateLab-tech/publishing-skills`
- Production-derived: extracted from the editorial pipeline running [automatelab.tech](https://automatelab.tech)