### PR TITLE
Add game-build-team to Multi-Agent Systems / Orchestration Platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -458,6 +458,11 @@ Orchestrate multiple Claude agents to work together on complex tasks.
   - Deterministic build/test Workflow with an unskippable Tester gate; agent fan-out sized to host RAM
   - Pausable/resumable across sessions; also outputs a reverse-engineered ARCHITECTURE.md
 
+- [Varalix-Digitech-Solutions/game-build-team-skill](https://github.com/Varalix-Digitech-Solutions/game-build-team-skill) ![Stars](https://img.shields.io/github/stars/Varalix-Digitech-Solutions/game-build-team-skill?style=flat-square)
+  - Agent team (Manager, Creative Director, Logic & Animation Developers, Tester) that builds Godot 4 / GDScript game features
+  - Two unskippable gates — headless test gate + "is it fun" creative gate — then an on-device final pass
+  - Deterministic build/test Workflow; pausable/resumable across sessions and usage-limit cutoffs
+
 ### Parallel Processing
 
 - [Dicklesworthstone/claude_code_agent_farm](https://github.com/Dicklesworthstone/claude_code_agent_farm) ![Stars](https://img.shields.io/github/stars/Dicklesworthstone/claude_code_agent_farm?style=flat-square)


### PR DESCRIPTION
Adds **game-build-team** right after the clone-team entry (same author/family of skills).

A Claude Code skill that builds Godot 4 / GDScript game features with a coordinated agent team (Manager, Creative Director, Logic & Animation Developers, Tester). Two unskippable gates — a headless test gate and an "is it fun" creative gate — then an on-device final pass. Deterministic build/test Workflow; pausable/resumable across sessions and usage-limit cutoffs.

- Repo: https://github.com/Varalix-Digitech-Solutions/game-build-team-skill
- Site: https://game-build-team.varalix.com/

Entry matches the section's format (stars badge + three sub-bullets).