### PR TITLE
Add CreatorSkills to Comprehensive Skill Collections

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,12 @@ These repositories offer extensive collections of skills across multiple domains
   - Includes adjacent Codex, Hermes, and OpenClaw hubs for cross-agent comparison
   - Useful when you want a Claude-specific entry point without losing the broader ecosystem view
 
+- [CreatorSkills](https://creatorskills.co)
+  - Curated marketplace of 30+ downloadable AI skills for content creators
+  - Covers YouTube scripting, sponsorship analysis, content repurposing, and audience growth
+  - Skills use the open SKILL.md format and work with Claude, ChatGPT, and 20+ AI platforms
+  - Paid marketplace; skills are domain-specific and ready to install
+
 - [garrytan/gstack](https://github.com/garrytan/gstack) ![Stars](https://img.shields.io/github/stars/garrytan/gstack?style=flat-square)
   - Garry Tan's exact Claude Code setup
   - 6 opinionated tools for startup leadership


### PR DESCRIPTION
## Summary

Adds [CreatorSkills](https://creatorskills.co) to the **Comprehensive Skill Collections** section alongside the Chinese claude-skills directory and Remote OpenClaw Claude Skills — as a third web-platform entry for discovering downloadable skills.

CreatorSkills is a curated marketplace of 30+ downloadable AI skills purpose-built for content creators — YouTube scripting, sponsorship analysis, content repurposing, and audience growth. Skills use the open SKILL.md format and are compatible with Claude, ChatGPT, and 20+ AI platforms.

It's a good addition here because the "Comprehensive Skill Collections" section already accepts web platforms (not just GitHub repos), and this is the only skills marketplace specifically targeting content creators.