### PR TITLE
Add handoff — cross-agent task dispatcher for Claude Code / Codex

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -528,6 +528,10 @@ Orchestrate multiple Claude agents to work together on complex tasks.
   - Two human gates per feature plus memory feedback loop that persists decisions across sessions
 
 ---
+- [dazuiba/handoff](https://github.com/dazuiba/handoff) ![Stars](https://img.shields.io/github/stars/dazuiba/handoff?style=flat-square)
+  - Skill/subagent that delegates tasks to DeepSeek V4, Codex, or Opus without leaving your session
+  - Runs tasks in the background; result returns automatically when done
+  - Backed by handoff-cli; supports parallel tasks and session resume
 
 ## Security & Compliance
 


### PR DESCRIPTION
## What is handoff?

[handoff](https://github.com/dazuiba/handoff) is a skill/subagent (backed by handoff-cli) that lets you delegate tasks to DeepSeek V4, Codex, or Claude Opus right inside your Claude Code / Codex session — without switching tools or losing context.

- Runs the delegated task in the background; your session never blocks
- Result comes back automatically when the task finishes
- Supports parallel tasks and resuming past sessions

## Why it belongs here

handoff is a multi-agent orchestration skill that coordinates Claude Code / Codex with DeepSeek and other agents.

## Links

- GitHub: https://github.com/dazuiba/handoff
- Install: `uv tool install handoff-cli && handoff init`
