### PR TITLE
Add rednote-writing-skill to Marketing & Content

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -702,6 +702,12 @@ Skills for marketing professionals, content creators, and growth teams.
   - 7 styles, UML support, and AI/Agent workflow patterns
   - Python-driven
 
+- [aislinn-yang/rednote-writing-skill](https://github.com/aislinn-yang/rednote-writing-skill) ![Stars](https://img.shields.io/github/stars/aislinn-yang/rednote-writing-skill?style=flat-square)
+  - Writes Rednote (Xiaohongshu / 小红书) posts in your own voice, never fabricating content
+  - Collage / co-create / review modes turn rough ideas into a finished draft
+  - Scans for AI-tells and platform-throttling words, then a "reads like a real person" pass before title and cover
+  - MIT licensed, instruction-only (no executable scripts); tune `examples.md` to match your own writing
+
 ---
 
 ## Domain-Specific Skills


### PR DESCRIPTION
Adds one skill to the **Marketing & Content** section.

**[rednote-writing-skill](https://github.com/aislinn-yang/rednote-writing-skill)** turns scattered ideas, notes, and raw material into a finished Rednote (Xiaohongshu / 小红书) post. It keeps the author's judgment and voice and never fabricates content. Three modes (collage / co-create / review), and before publishing it scans for AI-tells and platform-throttling words, then does a fresh "reads like a real person" pass. MIT licensed, instruction-only with no executable scripts.

Checklist against CONTRIBUTING:
- Actively maintained, MIT licensed
- Clear bilingual (EN / 中文) README with install and customization steps
- Fills a gap: the only Rednote / Chinese-social-media writing skill in this list