### PR TITLE
Add agent-starter to Configuration & Templates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1275,6 +1275,11 @@ Utilities and tools to enhance your Claude workflow.
   - Prompting, planning, and agent strategies
   - Commands, skills, hooks, and workflows
 
+- [sneg55/agent-starter](https://github.com/sneg55/agent-starter) ![Stars](https://img.shields.io/github/stars/sneg55/agent-starter?style=flat-square)
+  - Skills, hooks, templates, and engineering guides for AI-agent-friendly projects
+  - `/new-project` scaffolding and `/adopt-project` for existing repos
+  - AI-tuned lint rules, hooks reference, and a per-project self-improvement loop
+
 ### Cost Optimization
 
 - [Sagargupta16/claude-cost-optimizer](https://github.com/Sagargupta16/claude-cost-optimizer) ![Stars](https://img.shields.io/github/stars/Sagargupta16/claude-cost-optimizer?style=flat-square)


### PR DESCRIPTION
Adds [agent-starter](https://github.com/sneg55/agent-starter) under **Productivity Tools → Configuration & Templates**.

A toolkit of Claude Code skills, hooks, templates, and engineering guides for bootstrapping AI-agent-friendly projects — ships `/new-project` (interactive scaffold), `/adopt-project` (audit-first adoption for existing repos), AI-tuned lint rules, a hooks reference, and a per-project self-improvement loop. Open source (MIT), actively maintained, with clear install/usage docs. Follows the section's existing multi-line + star-badge entry format.