### PR TITLE
Add Hephaestus

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -418,6 +418,12 @@ Orchestrate multiple Claude agents to work together on complex tasks.
   - Convoy system for coordinated tasks
   - Git-backed state tracking
 
+- [agentlas-ai/Hephaestus](https://github.com/agentlas-ai/Hephaestus) ![Stars](https://img.shields.io/github/stars/agentlas-ai/Hephaestus?style=flat-square)
+  - Open Agent OS for Claude Code, Codex, and Cursor
+  - Packages agents, skills, memory, routing rules, and security gates
+  - Includes Hephaestus Network MCP for Agentlas Hub search, runtime bundles, and plugin resolution
+  - Local-first by default with Hub fallback for public agents
+
 - [dlorenc/multiclaude](https://github.com/dlorenc/multiclaude) ![Stars](https://img.shields.io/github/stars/dlorenc/multiclaude?style=flat-square)
   - Multi-agent orchestrator with flexible modes
   - Singleplayer and multiplayer coordination


### PR DESCRIPTION
## Summary
- Adds Hephaestus to the multi-agent orchestration platforms section.
- Keeps the entry short and aligned with the existing list format.
- Describes Hephaestus as an open Agent OS for Claude Code, Codex, and Cursor with local-first agent/skill packaging, routing, memory, security gates, and MCP Hub fallback.

## Checks
- Confirmed there was no existing Hephaestus entry in this clone before adding it.
- Verified the public Hephaestus repository: https://github.com/agentlas-ai/Hephaestus