### PR TITLE
Add Finance, Legal & Recruiting skill packs (Domain-Specific)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -729,6 +729,11 @@ Skills for marketing professionals, content creators, and growth teams.
 
 ## Domain-Specific Skills
 
+- [Uhudsavasindankacanokcu2/finance-skills-for-claude](https://github.com/Uhudsavasindankacanokcu2/finance-skills-for-claude) ![Stars](https://img.shields.io/github/stars/Uhudsavasindankacanokcu2/finance-skills-for-claude?style=flat-square) - Cash flow, runway, invoices, budgets & scenario modeling for founders/finance teams
+- [Uhudsavasindankacanokcu2/legal-skills-for-claude](https://github.com/Uhudsavasindankacanokcu2/legal-skills-for-claude) ![Stars](https://img.shields.io/github/stars/Uhudsavasindankacanokcu2/legal-skills-for-claude?style=flat-square) - Contract review, summarization, drafting & negotiation redlines in plain English
+- [Uhudsavasindankacanokcu2/recruiting-skills-for-claude](https://github.com/Uhudsavasindankacanokcu2/recruiting-skills-for-claude) ![Stars](https://img.shields.io/github/stars/Uhudsavasindankacanokcu2/recruiting-skills-for-claude?style=flat-square) - Job descriptions, bias-aware resume screening & structured interview kits
+
+
 Specialized skills for specific industries and use cases.
 
 - [Donchitos/Claude-Code-Game-Studios](https://github.com/Donchitos/Claude-Code-Game-Studios) ![Stars](https://img.shields.io/github/stars/Donchitos/Claude-Code-Game-Studios?style=flat-square)


### PR DESCRIPTION
Three business/professional skill packs for the Domain-Specific section:

- **Finance** — cash flow, runway, invoices, budgets, scenario modeling
- **Legal** — contract review/summary/drafting, negotiation redlines
- **Recruiting & HR** — JDs, bias-aware resume screening, interview kits

Clean single-file SKILL.md sets, work out of the box. Thanks for the list! 🙏