### PR TITLE
feat: add NotFair — SEO, GEO & paid-ads Claude Code skills

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -642,6 +642,13 @@ Skills for marketing professionals, content creators, and growth teams.
   - Connects Search Console and Google Ads for actionable audits
   - Includes SEO analysis, content writing, and CMS setup skills
 
+- [nowork-studio/NotFair](https://github.com/nowork-studio/NotFair) ![Stars](https://img.shields.io/github/stars/nowork-studio/NotFair?style=flat-square)
+  - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads (MIT)
+  - [SEO skills](https://github.com/nowork-studio/NotFair/tree/main/seo): site analysis, keyword research, meta tags, schema markup, GEO optimization, and content writing
+  - [Google Ads skills](https://github.com/nowork-studio/NotFair/tree/main/google-ads): audits, wasted-spend detection, search-term cleanup, keyword and bid management
+  - [Meta Ads skills](https://github.com/nowork-studio/NotFair/tree/main/meta-ads): ROAS analysis, creative fatigue, and audience overlap detection
+  - Connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP
+
 - [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) ![Stars](https://img.shields.io/github/stars/salespeak-ai/buyer-eval-skill?style=flat-square)
   - Structured B2B software vendor evaluation skill (MIT)
   - Domain-expert questions per software category


### PR DESCRIPTION
Hi, thanks for maintaining this list — it's a great resource for the Claude Code community.

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)** to the Marketing & Content section. NotFair is an open-source set of Claude Code skills (~2.9k stars, MIT) covering three areas:

- **SEO / GEO** — site analysis, keyword research, meta tags, schema markup, GEO optimization, and content writing
- **Google Ads** — audits, wasted-spend detection, search-term cleanup, keyword and bid management
- **Meta Ads** — ROAS analysis, creative fatigue, and audience overlap detection

It connects to live account data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP, so the skills work against real campaigns rather than static examples.

Happy to reword, reposition, or trim the entry to better match your preferred style. Thanks for your time!