### PR TITLE
Add agent-skill-groups

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -983,6 +983,11 @@ Utilities and tools to enhance your Claude workflow.
   - One rule set propagates to Claude Code, Cursor, Codex, and others
   - TypeScript-driven
 
+- [go165/agent-skill-groups](https://github.com/go165/agent-skill-groups) ![Stars](https://img.shields.io/github/stars/go165/agent-skill-groups?style=flat-square)
+  - Local-first Agent Skills profile manager for grouping `SKILL.md` directories by scenario
+  - Switches lean profiles such as core, research, frontend, and CTF with backup and restore support
+  - Supports Claude Code, Codex, OpenCode, and generic local skill roots with JSON automation output
+
 - [notlikeDev/CCPlugins](https://github.com/notlikeDev/CCPlugins) ![Stars](https://img.shields.io/github/stars/notlikeDev/CCPlugins?style=flat-square)
   - Claude Code framework focused on saving time on routine prompts
   - Built for developers tired of writing "please act like a senior engineer" every session


### PR DESCRIPTION
## Summary
- Add go165/agent-skill-groups to Agent Harnesses & Meta-Tools.
- It is a local-first Agent Skills profile manager for grouping and switching SKILL.md directories by scenario.
- It supports Claude Code, Codex, OpenCode, and generic local skill roots with backup/restore and JSON output.

## Why it fits
- The project helps users keep Claude Code skill sets lean by loading scenario profiles only when needed.
- It is not a SaaS wrapper and does not require a hosted service.

## Validation
- Checked the README diff only.
- Ran: git diff --check
