### PR TITLE
Add open-bridge to Memory & Context Management

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1114,6 +1114,12 @@ Utilities and tools to enhance your Claude workflow.
   - Also ships an MCP server, CLI, libraries (Rust, Python, Ruby, Swift, Kotlin), and a WASM/JS npm package
   - Rust-based, MPL-2.0 licensed
 
+- [bks-lab/open-bridge](https://github.com/bks-lab/open-bridge) ![Stars](https://img.shields.io/github/stars/bks-lab/open-bridge?style=flat-square)
+  - Agent-agnostic context layer: a plain git repo of Markdown + YAML your coding agent reads at the start of every session
+  - It begins each session knowing your repos, clients, and task conventions instead of restarting from zero
+  - One `skills/` tree works across Claude Code, Codex, and Copilot CLI; sync is via plain files/Git
+  - MIT licensed; single self-hosted instance so far — documents the method, not adoption
+
 ### MCP Servers & Integrations
 
 - [oraios/serena](https://github.com/oraios/serena) ![Stars](https://img.shields.io/github/stars/oraios/serena?style=flat-square)


### PR DESCRIPTION
Adds **open-bridge** to **Memory & Context Management** — it sits alongside entries like `akephalos` and `obsidian-mind` (plain-files/Git, markdown-first context that persists across sessions).

[bks-lab/open-bridge](https://github.com/bks-lab/open-bridge) — an agent-agnostic context layer: a plain git repo of Markdown + YAML your coding agent reads at the start of every session, so it begins each session knowing your repos, clients, and task conventions instead of restarting from zero. One `skills/` tree works across Claude Code, Codex, and Copilot CLI; sync is via plain files/Git. MIT licensed.

Format matched to the section (`![Stars]` shields badge + indented description bullets). To be transparent: it is a single self-hosted instance so far — the last bullet states that the repo documents the method, not adoption.