### PR TITLE
Add intelligence-sync to CLI Configuration Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1240,9 +1240,9 @@ Utilities and tools to enhance your Claude workflow.
 
 - [ainova-systems/intelligence-sync](https://github.com/ainova-systems/intelligence-sync) ![Stars](https://img.shields.io/github/stars/ainova-systems/intelligence-sync?style=flat-square)
   - One source of truth for AI coding rules across every IDE
-  - Author rules, agents, and skills once in plain markdown
-  - Routes them into each tool's native format (Claude Code, Cursor, Copilot, Codex, AGENTS.md)
-  - Zero dependencies, bash and awk, MIT
+  - Author rules, agents, and skills once in plain Markdown
+  - Routes them into each tool's native formats (Claude Code, Cursor, GitHub Copilot, Codex, AGENTS.md)
+  - Zero-dependency, bash and awk, MIT licensed
 
 ### Autonomous Development
 

--- a/readme.md
+++ b/readme.md
@@ -1238,6 +1238,12 @@ Utilities and tools to enhance your Claude workflow.
   - Zero-Config Code Flow for Claude Code and Codex
   - TypeScript-driven configuration wrapper
 
+- [ainova-systems/intelligence-sync](https://github.com/ainova-systems/intelligence-sync) ![Stars](https://img.shields.io/github/stars/ainova-systems/intelligence-sync?style=flat-square)
+  - One source of truth for AI coding rules across every IDE
+  - Author rules, agents, and skills once in plain markdown
+  - Routes them into each tool's native format (Claude Code, Cursor, Copilot, Codex, AGENTS.md)
+  - Zero dependencies, bash and awk, MIT
+
 ### Autonomous Development
 
 - [frankbria/ralph-claude-code](https://github.com/frankbria/ralph-claude-code) ![Stars](https://img.shields.io/github/stars/frankbria/ralph-claude-code?style=flat-square)


### PR DESCRIPTION
Adds intelligence-sync to Productivity Tools > CLI Configuration Tools.

It is an open-source (MIT), zero-dependency CLI (bash + awk) that lets a team author AI coding rules, agents, and skills once in plain markdown and routes them into each tool's native format (Claude Code, Cursor, Copilot, Codex, AGENTS.md), so standards stay in sync across editors. Same category as claude-code-templates and claude-code-router. Actively maintained, documented README, production-ready.
