### PR TITLE
Add Zero (officialzeroxyz/zero-plugins) to MCP Servers & Integrations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1185,6 +1185,12 @@ Utilities and tools to enhance your Claude workflow.
   - Three-tier channel scheduling, browser CDP, and parallel divide-and-conquer
   - JavaScript-driven
 
+- [officialzeroxyz/zero-plugins](https://github.com/officialzeroxyz/zero-plugins) ![Stars](https://img.shields.io/github/stars/officialzeroxyz/zero-plugins?style=flat-square)
+  - Claude Code plugin (zero@zero-plugins) that gives your AI access to thousands of tools, APIs and services to use and pay for per use
+  - No config, no API keys; services are discovered and paid for at runtime
+  - Also ships a CLI (@zeroxyz/cli) and an MCP connector (mcp.zero.xyz)
+  - Homepage: https://zero.xyz
+
 ### API & Integration Tools
 
 - [router-for-me/CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) ![Stars](https://img.shields.io/github/stars/router-for-me/CLIProxyAPI?style=flat-square)


### PR DESCRIPTION
## Summary

Adds **Zero** to Productivity Tools → MCP Servers & Integrations. Zero (`zero@zero-plugins`) is a Claude Code plugin that gives your AI access to thousands of tools, APIs and services it can use and pay for per use - no config and no API keys. It also ships a CLI (`@zeroxyz/cli`) and an MCP connector (`mcp.zero.xyz`). Free to start ($5 of credit; most calls cost pennies).

- Matches the section's `[owner/repo]` + stars-badge + sub-bullet format
- Inserted before the "API & Integration Tools" heading; not a duplicate

Disclosure: I work on Zero's go-to-market - happy to tweak the wording, move the section, or close this if it is not a fit.