### PR TITLE
Add redamancy231-create/claude-skills to Comprehensive Skill Collections

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -250,6 +250,14 @@ These repositories offer extensive collections of skills across multiple domains
   - Covers email sending, sandbox testing, templates, domain setup, and contacts
    -Follows the Agent Skills open standard (Anthropic, Dec 2025)
 
+- [redamancy231-create/claude-skills](https://github.com/redamancy231-create/claude-skills) ![Stars](https://img.shields.io/github/stars/redamancy231-create/claude-skills?style=flat-square)
+  - 3 professional Claude Code skills: session-end, write-claude-md, kill-test-first
+  - session-end: structured session wrap-up with passive observation capture and memory persistence
+  - write-claude-md: five-step protocol for codebase documentation, vetted through 3-backend independent review
+  - kill-test-first: enforce test-first methodology in AI-assisted development
+  - All skills validated through multi-model independent review (Codex + Kimi + Qwen)
+
+
 ## Development & Engineering
 
 Skills focused on software development, code quality, and engineering workflows.


### PR DESCRIPTION
## Project

- Name: redamancy231-create/claude-skills
- URL: https://github.com/redamancy231-create/claude-skills
- Category: Comprehensive Skill Collections

## Why it belongs

A curated collection of 3 professional Claude Code skills — session-end, write-claude-md, and kill-test-first — designed to improve AI-assisted development workflows. Each skill has been independently validated through multi-model review (Codex + Kimi + Qwen) and addresses a specific gap in the Claude Code skill ecosystem.

## Quality signals

- License: MIT
- Maintenance status: Actively maintained (published July 2026, code-reviewed by 3 independent AI backends)
- Documentation: Each skill includes bilingual SKILL.md with Quick Reference routing table, EXAMPLES.md, and a checklist
- Distinction: Unlike general-purpose skill collections, these 3 skills follow a unified design protocol (P0→P1→P2 three-phase refactoring, router pattern with progressive disclosure). This methodology itself is documented and reproducible — other skill authors can adopt it.