### PR TITLE
Add claude-video-plus (video Q&A skill) to Domain-Specific Skills

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -952,6 +952,12 @@ Specialized skills for specific industries and use cases.
   - Judgment-first: won't flatten prompts that need precise control
   - One SKILL.md, open Agent Skills standard; MIT
 
+- [abe238/claude-video-plus](https://github.com/abe238/claude-video-plus) ![Stars](https://img.shields.io/github/stars/abe238/claude-video-plus?style=flat-square)
+  - Ask a video a question — retrieves only the chapters, numeric facts, and on-screen moments that answer it instead of sampling the whole timeline
+  - Sealed, receipt-gated benchmark matched the original's blind-judged answer quality (8.83 vs 8.80) at ~56% fewer tokens; 338 deterministic tests
+  - Fails open: reverts to the original pipeline on no captions, local file, short video, or any error
+  - Install with `npx skills add abe238/claude-video-plus -g`; attributed MIT fork of bradautomates/claude-video with upstream authorship preserved
+
 
 ## Productivity Tools
 


### PR DESCRIPTION
## What this adds

One entry under **Domain-Specific Skills** for [abe238/claude-video-plus](https://github.com/abe238/claude-video-plus): a `/watch` skill that lets you ask a video a question and retrieves only the chapters, numeric facts, and on-screen moments that answer it, instead of sampling the whole timeline.

## Install

```
npx skills add abe238/claude-video-plus -g
```

(Claude Code: `/plugin marketplace add abe238/claude-video-plus` then `/plugin install watch@claude-video-plus`)

## Why it meets the list's bar

- **Verified quality, not a claim:** a sealed, receipt-gated benchmark matched the original pipeline's blind-judged answer quality (8.83 vs 8.80) at ~56% fewer tokens.
- **Production-ready:** 338 deterministic tests, and it fails open — reverts to the original pipeline on no captions, a local file, a short video, or any error.
- **Properly attributed:** an MIT fork of [bradautomates/claude-video](https://github.com/bradautomates/claude-video) with upstream authorship preserved.

Placed next to the existing media/video skills in Domain-Specific Skills, matching the section's multi-line bullet + star-badge format. Single-line diff-clean addition; no other lines touched.
