### PR TITLE
Add idea-hunt skill

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -671,6 +671,12 @@ n- [GiulioDER/cca-audit](https://github.com/GiulioDER/cca-audit) ![Stars](https:
 
 Skills for marketing professionals, content creators, and growth teams.
 
+- [ANVEAI/idea-hunt-skill](https://github.com/ANVEAI/idea-hunt-skill) ![Stars](https://img.shields.io/github/stars/ANVEAI/idea-hunt-skill?style=flat-square)
+  - Evidence-first AI business idea discovery and validation (MIT)
+  - Finds a painful, already-paid-for workflow AI can replace, then proves willingness-to-pay before you build
+  - 7-stage pipeline: pain mining, kill-gates, the Mom Test, and a proof-of-wallet test
+  - Works with Claude Code, Claude Desktop, and any agent that loads skills
+
 - [cognyai/claude-code-marketing-skills](https://github.com/cognyai/claude-code-marketing-skills) ![Stars](https://img.shields.io/github/stars/cognyai/claude-code-marketing-skills?style=flat-square)
   - 5 free marketing skills, no account required
   - SEO Audit, Landing Page Review, Competitor Analysis


### PR DESCRIPTION
### Adding: idea-hunt

**Repo:** https://github.com/ANVEAI/idea-hunt-skill · MIT · single self-contained `SKILL.md` — no API key or paid subscription required to function.

**What it does:** Evidence-first AI business idea discovery & validation. It hunts for an existing, already-paid-for workflow AI can now do as *completed work*, then runs a 7-stage pipeline — pain mining → kill-gates → the Mom Test → a proof-of-wallet test — so weak ideas get rejected on paper before any build.

Added under **Marketing & Content**, matching the section's nested-bullet + stars-badge format.