### PR TITLE
Add pickysteve to Agent Harnesses & Meta-Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1069,6 +1069,11 @@ Utilities and tools to enhance your Claude workflow.
   - Reads real session transcripts to find skills, MCP servers, and agents that were loaded into context but never fired, then safely quarantines them
   - Supports Claude Code, Codex CLI, Hermes, OpenCode, Cursor, and OpenClaw; zero telemetry, single static Go binary
   - Scan / report / prune workflow keeps removals reversible; installable via Homebrew and npm (MIT)
+- [KernelLord/pickysteve](https://github.com/KernelLord/pickysteve) ![Stars](https://img.shields.io/github/stars/KernelLord/pickysteve?style=flat-square)
+  - Local-first skill router: a cheap local model (default Ollama qwen3:8b) routes each prompt to the right skill via hybrid BM25 + embedding retrieval (RRF-fused), cross-encoder rerank, and an LLM judge, then assembles a minimal context bundle for the execution model
+  - Built-in ONNX prompt-injection gate scans both the raw request and every retrieved document, fail-closed — 100% detection / 0 bypasses on a 180-payload red-team corpus, 0/43 false positives on the real registry
+  - MCP stdio server plus an OpenAI-compatible proxy (`:8077/v1`); one-command installer wires 18 coding agents including Claude Code, Codex, Cursor, and Windsurf
+  - MIT licensed, Python 3.11; early-stage (v0.1.0, released 2026-07-06)
 
 ### Memory & Context Management
 


### PR DESCRIPTION
Adds pickysteve alongside the other skill-routing/meta context-management tools.

Local-first skill router: retrieval + rerank + LLM judge pick the right skill per prompt; fail-closed ONNX injection gate scans request and retrieved docs; MCP stdio + OpenAI-compatible proxy; installer covers 18 agents including Claude Code. Factual sub-bullets follow the section's format, including honest early-stage note (v0.1.0).

Disclosure: I am the project author; this PR was prepared by Claude (agent) on my behalf.