### PR TITLE
Add breaking-coding-chaos (dual-loop control-plane skills)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -354,6 +354,12 @@ Skills focused on software development, code quality, and engineering workflows.
   - Compatible with Claude Code, Hermes Agent, OpenClaw, Kilocode, Copilot, and Mastra
   - Python-backed and MIT licensed
 
+- [bo-cao/breaking-coding-chaos](https://github.com/bo-cao/breaking-coding-chaos) ![Stars](https://img.shields.io/github/stars/bo-cao/breaking-coding-chaos?style=flat-square)
+  - Human-in-the-loop dual-loop control-plane skill suite for coding agents
+  - throughline (progress cockpit) → plan-spar (align+lock PLAN) → clean-cut (minimal implement + verify)
+  - Standard Agent Skills layout; works with Claude Code, Codex, Cursor, Grok, OpenCode, Hermes, OpenClaw
+  - MIT licensed
+
 - [mturac/pluginpool](https://github.com/mturac/pluginpool) ![Stars](https://img.shields.io/github/stars/mturac/pluginpool?style=flat-square)
   - Ten focused Claude Code plugins for everyday developer productivity
   - Includes **commit-narrator**, **pr-storyteller**, **test-gap**, **deps-doctor**, **env-lint**, **secret-guard**, **standup-gen**, **todo-harvest**, **flaky-detector**, **changelog-forge**


### PR DESCRIPTION
## What
Add [breaking-coding-chaos](https://github.com/bo-cao/breaking-coding-chaos) (BCC).

## Why
Open MIT dual-loop control-plane **skill suite** for coding agents:

1. **throughline** — durable progress / plans / findings on disk
2. **plan-spar** — grill and lock a PLAN before code
3. **clean-cut** — smallest correct implement + verify

Standard Agent Skills layout. Works with Claude Code, Codex CLI, Cursor, Grok, OpenCode, Hermes, OpenClaw.

I'm the author ([bo-cao](https://github.com/bo-cao)).