### PR TITLE
Add oss-distributor

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -787,6 +787,12 @@ Skills for marketing professionals, content creators, and growth teams.
   - 12 business-analysis skills for marketers, growth & business analysts (not just coders)
   - Competitor teardown, funnel audit, pricing analysis, offer/value ladder, ICP segmentation, SEO content-gap
   - Installable as a Claude Code plugin (`/plugin marketplace add fjilvi-afk/growthlens`); MIT
+
+- [yarin-hochman1/oss-distributor](https://github.com/yarin-hochman1/oss-distributor) ![Stars](https://img.shields.io/github/stars/yarin-hochman1/oss-distributor?style=flat-square)
+  - Gets your open-source project listed in GitHub awesome-lists and registries
+  - Refreshes a live GitHub snapshot, scores ecosystem-fit candidates, and opens PRs only after explicit approval
+  - Rate-limited to 5 PRs per session; skips lists requiring human-only attestations; MIT
+  - Install: `git clone https://github.com/yarin-hochman1/oss-distributor ~/.claude/agents/oss-distributor`
 ---
 
 ## Domain-Specific Skills


### PR DESCRIPTION
Adds [oss-distributor](https://github.com/yarin-hochman1/oss-distributor) to the Marketing & Content section.

**What it is**: Refreshes a live GitHub snapshot of your repo, searches for awesome-lists and registries that fit your project's ecosystem, scores each candidate for fit, and opens pull requests only after you explicitly approve. Rate-limited to 5 PRs per session, skips lists that require human-only attestations, and never invents statistics about your project.

**License**: MIT
**Install**:
```
git clone https://github.com/yarin-hochman1/oss-distributor ~/.claude/agents/oss-distributor
```

Fits under Marketing & Content because it's a growth/distribution tool for open-source and Claude Code projects, in the same vein as the other GTM-oriented entries already listed there (e.g. outreachmagic).