### PR TITLE
Add UIZZE UI finish-gate skill

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -256,7 +256,7 @@ Skills focused on software development, code quality, and engineering workflows.
 
 ### Core Development Skills
 
-- [samuelbushi/uizze](https://github.com/uizze/uizze) ![Stars](https://img.shields.io/github/stars/uizze/uizze?style=flat-square)
+- [uizze/uizze](https://github.com/uizze/uizze) ![Stars](https://img.shields.io/github/stars/uizze/uizze?style=flat-square)
   - Stops Claude Code, Codex, and Cursor from shipping generic UI slop
   - Uses UIZZE's free catalogue of 800,000+ real web and iOS screens to build product-specific design contracts
   - Adds a hard finish gate for hierarchy, states, responsive behavior, and design-system drift

--- a/readme.md
+++ b/readme.md
@@ -256,6 +256,12 @@ Skills focused on software development, code quality, and engineering workflows.
 
 ### Core Development Skills
 
+- [samuelbushi/uizze](https://github.com/samuelbushi/uizze) ![Stars](https://img.shields.io/github/stars/samuelbushi/uizze?style=flat-square)
+  - Stops Claude Code, Codex, and Cursor from shipping generic UI slop
+  - Uses UIZZE's free catalogue of 800,000+ real web and iOS screens to build product-specific design contracts
+  - Adds a hard finish gate for hierarchy, states, responsive behavior, and design-system drift
+  - Optional full MCP for in-agent catalogue search, audits, and screenshot critique at [uizze.com](https://uizze.com)
+
 - [gyujeongion/claude-code-rootcause](https://github.com/gyujeongion/claude-code-rootcause) ![Stars](https://img.shields.io/github/stars/gyujeongion/claude-code-rootcause?style=flat-square)
   - Turns "never do X" bans into positive process gates
   - Audits your instruction file for ban bloat (rethink + deusex)

--- a/readme.md
+++ b/readme.md
@@ -256,7 +256,7 @@ Skills focused on software development, code quality, and engineering workflows.
 
 ### Core Development Skills
 
-- [samuelbushi/uizze](https://github.com/samuelbushi/uizze) ![Stars](https://img.shields.io/github/stars/samuelbushi/uizze?style=flat-square)
+- [samuelbushi/uizze](https://github.com/uizze/uizze) ![Stars](https://img.shields.io/github/stars/uizze/uizze?style=flat-square)
   - Stops Claude Code, Codex, and Cursor from shipping generic UI slop
   - Uses UIZZE's free catalogue of 800,000+ real web and iOS screens to build product-specific design contracts
   - Adds a hard finish gate for hierarchy, states, responsive behavior, and design-system drift


### PR DESCRIPTION
## What changed

- Added UIZZE in the most relevant skill or MCP category.
- Described the free 800,000+ screen catalogue workflow, product-specific design contract, and pre-ship finish gate.
- Linked the optional full MCP at https://uizze.com.

## Why

UIZZE gives coding-agent users a concrete way to stop generic UI slop: reference real web and iOS patterns, make the design decisions explicit, then verify the rendered result before shipping. The public repository includes an instruction-only skill with no scripts, executables, dependencies, or secret requirements.

Disclosure: I maintain UIZZE.