### PR TITLE
Add Accessible Dark Mode Design Expert

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -798,6 +798,12 @@ Skills for marketing professionals, content creators, and growth teams.
 
 Specialized skills for specific industries and use cases.
 
+- [dhosruiasn/accessible-dark-mode-design-expert](https://github.com/dhosruiasn/accessible-dark-mode-design-expert) ![Stars](https://img.shields.io/github/stars/dhosruiasn/accessible-dark-mode-design-expert?style=flat-square)
+  - Accessible light/dark theme design, implementation, review, and audit skill for Claude Code and OpenAI Codex
+  - Covers user preference precedence, semantic design tokens, WCAG text and non-text contrast, theme-aware assets, Material and Apple conventions, and reduced-motion-safe transitions
+  - Ships a deterministic contrast calculator, safe cross-runtime installation sync, automated tests, and bilingual Traditional Chinese/English documentation
+  - MIT licensed; invoked as `/accessible-dark-mode-design-expert`
+
 - [Donchitos/Claude-Code-Game-Studios](https://github.com/Donchitos/Claude-Code-Game-Studios) ![Stars](https://img.shields.io/github/stars/Donchitos/Claude-Code-Game-Studios?style=flat-square)
   - Turn Claude Code into a full game development studio
   - 48 AI agents and 37 workflow skills


### PR DESCRIPTION
## Summary

Adds Accessible Dark Mode Design Expert to Domain-Specific Skills.

## Project quality

- Production-ready SKILL.md package for Claude Code and OpenAI Codex.
- Deterministic WCAG contrast calculation, source-level theme surface inventory, automated tests, and safe cross-runtime installation sync.
- Covers semantic tokens, user preference precedence, theme-aware assets, Material and Apple conventions, prefers-reduced-motion, and whole-product route/surface/state acceptance.
- Traditional Chinese and English documentation, MIT license, public v2.1.0 release, logo, social preview, and verified UI example.
- Model-layer invocation was verified in Claude Code 2.1.214 and the current Codex desktop CLI.

## v2.1.0 production-tested update

The v2.1.0 workflow was derived from a production Pickmin dark-theme rollout. Real implementation findings—authenticated and role-gated routes, portals and overlays, generated entry points, third-party surfaces, responsive states, duplicate selected-state layers, and transition afterimages—were converted into reusable acceptance rules.

The new inventory tool reports source candidates for raw colors, inline styles, SVG colors, pseudo-elements, transitions, animations, visual effects, overlays, and external surfaces. Candidate counts can overlap and are not presented as confirmed defects; the Skill requires browser evidence across Light, Dark, System, mobile, desktop, and applicable states before a completion claim.

Release: https://github.com/dhosruiasn/accessible-dark-mode-design-expert/releases/tag/v2.1.0

The change is limited to one entry in the existing Domain-Specific Skills section.
