### PR TITLE
Add report-skills (Marketing & Content)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -787,6 +787,12 @@ Skills for marketing professionals, content creators, and growth teams.
   - 12 business-analysis skills for marketers, growth & business analysts (not just coders)
   - Competitor teardown, funnel audit, pricing analysis, offer/value ladder, ICP segmentation, SEO content-gap
   - Installable as a Claude Code plugin (`/plugin marketplace add fjilvi-afk/growthlens`); MIT
+
+- [dashaworks/report-skills](https://github.com/dashaworks/report-skills) ![Stars](https://img.shields.io/github/stars/dashaworks/report-skills?style=flat-square)
+  - 5 skills for Claude Code and Codex that publish agent-made content as beautiful live web pages (MIT)
+  - Research/analysis → shareable web reports, recurring client reports (SEO monthlies), and view-tracked proposals (a DocSend alternative)
+  - Slide decks plus a design-polish pass, all on-brand via the ReportRoom MCP; view analytics returned to the agent after publish
+  - Install: `/plugin marketplace add dashaworks/report-skills`
 ---
 
 ## Domain-Specific Skills


### PR DESCRIPTION
Adds [dashaworks/report-skills](https://github.com/dashaworks/report-skills) under **Marketing & Content**, matching the section's entry format (repo link + stars badge + sub-bullets).

A bundle of 5 MIT-licensed skills for Claude Code and Codex that turn agent-made content into beautiful live web pages:

- **report-publisher** — research/analysis → a designed, shareable web report
- **client-reporter** — recurring branded client reports (SEO monthlies, status, audits)
- **proposal-tracker** — view-tracked proposal links (a DocSend alternative)
- **deck-publisher** — content → responsive slide deck
- **report-designer** — polish an existing page to the design bar

Published via the ReportRoom MCP, with view analytics returned to the agent.