### PR TITLE
Add claude-code-eyes to Domain-Specific Skills

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -952,6 +952,11 @@ Specialized skills for specific industries and use cases.
   - Judgment-first: won't flatten prompts that need precise control
   - One SKILL.md, open Agent Skills standard; MIT
 
+- [fcavalcantirj/claude-code-eyes](https://github.com/fcavalcantirj/claude-code-eyes) ![Stars](https://img.shields.io/github/stars/fcavalcantirj/claude-code-eyes?style=flat-square)
+  - Give Claude Code eyes — look at real hardware, displays, LCDs and wiring through a camera (Android IP Webcam, Pi cam, or any snapshot URL)
+  - Visual-verify a rendered panel and catch bugs that live on the glass, not in the logs; check wiring before power-on
+  - ~100 lines of bash + a SKILL.md, MIT, one-command setup
+
 
 ## Productivity Tools
 


### PR DESCRIPTION
Adds [claude-code-eyes](https://github.com/fcavalcantirj/claude-code-eyes) — an open-source (MIT) Claude Code skill that lets Claude see real hardware, displays, and wiring through a camera (Android IP Webcam, Raspberry Pi camera-streamer, or any snapshot URL) and read the frame: to visually verify a rendered panel or check wiring/voltage rails before power-on, catching output no unit test, log, or API can. ~100 lines of bash + a SKILL.md, one-command setup, tested under bash 3.2. Live and in active use (18+ stars, 50+ clones in the first day).