### PR TITLE
Add mem0ry4ai to Memory & Context Management

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1169,6 +1169,13 @@ Utilities and tools to enhance your Claude workflow.
   - One `skills/` tree works across Claude Code, Codex, and Copilot CLI; sync is via plain files/Git
   - MIT licensed; single self-hosted instance so far — documents the method, not adoption
 
+- [cremenescu/mem0ry4ai](https://github.com/cremenescu/mem0ry4ai) ![Stars](https://img.shields.io/github/stars/cremenescu/mem0ry4ai?style=flat-square)
+  - Local-first persistent memory whose source of truth is plain markdown files versioned by git — no cloud, no DB server, no telemetry, no API keys
+  - SessionStart hook injects the project-scoped slice of memory and SessionEnd captures new memories and commits them; also packaged as a Claude Code plugin
+  - Built-in stdio MCP server (8 tools, including full-text search over past session transcripts) works with Claude Code, Gemini CLI, Cursor, and OpenCode
+  - Hybrid SQLite FTS5 plus optional local Ollama embeddings fused with RRF, degrading to keyword search offline; secrets redacted on write and local-model proposals held in a human review queue
+  - Pure Python stdlib with no pip install or third-party deps; macOS, Linux, and Windows; bilingual EN/RO web UI; GPL-2.0-or-later
+
 ### MCP Servers & Integrations
 
 - [oraios/serena](https://github.com/oraios/serena) ![Stars](https://img.shields.io/github/stars/oraios/serena?style=flat-square)


### PR DESCRIPTION
Adds **mem0ry4ai** to `### Memory & Context Management` (under Productivity Tools), appended at the end of that section immediately before `### MCP Servers & Integrations`.

It sits naturally alongside the existing entries there — akephalos, open-bridge, accreted-intelligence, Continuous-Claude-v3 — same species of tool: local-first, file-based memory/context for Claude Code.

What it does: plain markdown files versioned by git are the source of truth (no cloud, no DB server, no telemetry, no API keys). A SessionStart hook injects the project-scoped slice of memory into every session and a SessionEnd hook captures new memories and git-commits them. It also ships a stdio MCP server (8 tools, including full-text search over past session transcripts), so the same store works from Gemini CLI, Cursor and OpenCode. Retrieval is SQLite FTS5 fused with optional local Ollama embeddings via RRF, degrading to keyword search when offline. Secrets are redacted before every write. Pure Python stdlib — no `pip install`.

Format matched to the section: `![Stars]` shields badge on the link line plus indented description bullets. No changes outside that one section; the `## Contents` TOC lists H2 headings only, so it needs no update.

To be transparent: I'm the author, the repo went public on 2026-06-11 and has no stars yet. It's at v0.16.0, fully documented, packaged as a Claude Code plugin, and in daily use.