### PR TITLE
Add SkillsIndex to Comprehensive Skill Collections

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -249,6 +249,11 @@ These repositories offer extensive collections of skills across multiple domains
   - Agent skills for Mailtrap email sending, sandbox testing, and contact management
   - Covers email sending, sandbox testing, templates, domain setup, and contacts
    -Follows the Agent Skills open standard (Anthropic, Dec 2025)
+- [SkillsIndex](https://skillsindex.dev)
+  - Searchable index of 1,272 Claude skills alongside 4,330 MCP servers, GPT actions, and IDE plugins
+  - Every entry scored 0-100, assembled from separate security, utility, and maintenance ratings
+  - Built for checking what a skill does and how it scores on security before installing it, with a published scoring method
+  - Agent-native lookups through its own MCP server, [skillsindex-mcp](https://github.com/thomasblc/skillsindex-mcp)
 
 ## Development & Engineering
 


### PR DESCRIPTION
Adds SkillsIndex to **Comprehensive Skill Collections**, in the same vein as the other web directories already listed there (Claude Code Skills 中文精选集, Remote OpenClaw Claude Skills).

Disclosure: I run it.

What it adds next to the entries already in that section: it indexes 1,272 Claude skills alongside 4,330 MCP servers, GPT actions and IDE plugins, and each entry carries a 0-100 score assembled from separate security, utility and maintenance ratings, so a skill can be checked before it is installed. The scoring method is published at https://skillsindex.dev/methodology/. There is also an MCP server, `skillsindex-mcp`, for agents that want to query the index directly.

Against your four criteria: actively maintained (catalog and scores refreshed continuously), documented method page, and the security score is the part that is genuinely useful to Claude users rather than another list of links.

+5 / -0, one section, no other changes.
