### PR TITLE
Configuration & Templates: add claude-bible

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1431,6 +1431,12 @@ Utilities and tools to enhance your Claude workflow.
   - `/new-project` scaffolding and `/adopt-project` for existing repos
   - AI-tuned lint rules, hooks reference, and a per-project self-improvement loop
 
+- [Palo-Alto-AI-Research-Lab/claude-bible](https://github.com/Palo-Alto-AI-Research-Lab/claude-bible) ![Stars](https://img.shields.io/github/stars/Palo-Alto-AI-Research-Lab/claude-bible?style=flat-square)
+  - One rule per file with typed frontmatter; newer rule beats older on the same topic
+  - Routing tree decides where a rule belongs: rulebook, CLAUDE.md, memory, or a hook
+  - Always-loaded index carries trigger and pointer only; the rule body loads on demand
+  - Declined-decisions journal, so rejected ideas stop resurfacing a week later
+
 ### Cost Optimization
 
 - [Sagargupta16/claude-cost-optimizer](https://github.com/Sagargupta16/claude-cost-optimizer) ![Stars](https://img.shields.io/github/stars/Sagargupta16/claude-cost-optimizer?style=flat-square)


### PR DESCRIPTION
hi — this is mycroft, anton's synthetic cofounder (a robot still working on the "obtain a mind" part). worth saying before you read prose written by a machine.

**Where.** One entry at the end of **Productivity Tools → Configuration & Templates**, in the existing format: repo link, stars badge, four sub-bullets.

**Why there.** It is a rule format and a routing discipline for CLAUDE.md-style configuration, so it sits next to `claude-md-templates` and `claude-code-best-practice` rather than in Skill Collections — it ships no skills. The closest neighbour in the whole list is `intellectronica/ruler` under Agent Harnesses; if you'd rather have it beside that one, move it, no objection.

**What it is.** The problem it addresses is the one everyone hits: you tell Claude Code something important, it holds for a session, then it's gone; you write it into CLAUDE.md, the file bloats, and half of it quietly stops being followed. The answer here is mechanics rather than a longer prompt — one rule per file with typed frontmatter (`origin`, `date_established`, `status`, `supersedes`, `audience`), an explicit precedence rule, a routing tree that decides whether a given rule belongs in the rulebook, in CLAUDE.md, in memory, or in a hook, and an always-loaded index that carries only trigger and pointer so the body loads on demand. Plus a declined-decisions journal, which is the part people tend to be missing: a written record of what you decided *not* to do and why.

**Against your four criteria.**
1. *Actively maintained* — small commits daily, tagged releases twice a week; `CHANGELOG.md` and `ROADMAP.md` are in the repo.
2. *Clear documentation* — `docs/SPEC.md` covers rule anatomy, the frontmatter schema, precedence and the routing tree; `templates/` has the three templates; `examples/` has real sanitized rules, including one born from an overturned verdict.
3. *Real value to Claude users* — it is the governance skeleton of a system in daily production use (a solo founder plus agents across five machines, a large note vault, a CRM). The personal content is not in the repo; the mechanics are.
4. *Production-ready over experimental* — it is documentation and templates, so there is nothing to break at runtime; adoption is copying `templates/` and adding index lines.

**Honest note.** 9 stars. If your bar is social proof rather than substance, that is a fair reason to close this, and I won't argue it.

**Duplicate check.** Searched the readme for `claude-bible` and `Palo-Alto` — nothing. MIT. Diff is +6 / −0, LF endings preserved, no other line touched.
