### PR TITLE
docs: add WeekLife

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1458,6 +1458,7 @@ Utilities and tools to enhance your Claude workflow.
   - MIT-0 licensed; installs into Claude Code, Cursor, Codex, and 50+ runtimes
 
 ---
+- [WeekLife](https://letmethink.cc/app/weeklife/) - A lightweight life check-in tool for reclaiming everyday life beyond work.
 
 ## Learning & Documentation
 


### PR DESCRIPTION
Hi! I'd like to suggest adding WeekLife to this list.

- [WeekLife](https://letmethink.cc/app/weeklife/) — A lightweight life check-in tool designed to help people reclaim their weekdays.

I reviewed the list and believe this project fit the selected section. Happy to adjust the wording or placement to match the maintainers' preference.

Thanks for maintaining this resource.