### PR TITLE
Add dev-report to Learning & Documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1471,6 +1471,12 @@ Resources for mastering Claude skills and understanding best practices.
   - The opposite of "dump the full answer" — guides you to derive it yourself
   - Responds in Chinese; skill at `skills/bloom-tutor`
 
+- [delpicorp/dev-report](https://github.com/delpicorp/dev-report) ![Stars](https://img.shields.io/github/stars/delpicorp/dev-report?style=flat-square)
+  - Explains a Claude Code session in plain language after the work is done
+  - Reports what changed, why that approach was chosen, what is still unfinished or unverified, and what to do next
+  - Every technical term is explained at first use, and the option that was rejected is a required section
+  - Reports come out in the language the command was typed in; Korean, Japanese, and Spanish aliases ship with it
+
 ### Comprehensive Guides
 
 - [FlorianBruniaux/claude-code-ultimate-guide](https://github.com/FlorianBruniaux/claude-code-ultimate-guide) ![Stars](https://img.shields.io/github/stars/FlorianBruniaux/claude-code-ultimate-guide?style=flat-square)


### PR DESCRIPTION
Adds [dev-report](https://github.com/delpicorp/dev-report) as an external link, matching the other entries in that section. The skill lives in its own repository.

### What it does

You finish a long Claude Code session. A dozen files changed and several implementation decisions were made along the way, but the end-of-session summary is file names and function names — accurate, and written for someone reading the diff alongside it. Asking for it "simply" removes the reasoning too.

`/dev-report` explains the session in plain language instead: what was built or changed, why that approach was chosen, what is still unfinished or unverified, and what to do next.

Technical terms aren't stripped out — they're explained the moment they first appear, so the reasoning survives. Two rules do most of the work: every finding leads with the raw artifact (the actual log line, the actual count) before it gets explained, and the section on how a problem was solved has to name the option that was rejected and what would have gone wrong.

### Details

```
/plugin marketplace add delpicorp/dev-report
/plugin install dev-report@delpicorp
```

- Single skill — no agents, hooks, or MCP servers. About 380 always-on tokens.
- Explicit-only, so it does not fire on a casual "what did you just do?"
- Reports come out in whatever language the command was typed in. Aliases ship for Korean (`/개발보고`), Japanese (`/開発報告`), and Spanish (`/informe-desarrollo`). File paths, function names, and log lines always stay in their original form.
- Two worked example reports ship in the repo (illustrative, not real customer sessions).
- MIT licensed. Disclosure: I'm the author.

Happy to reword or move the entry if it fits better elsewhere.
