### PR TITLE
Add multi-llm-plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -532,6 +532,10 @@ Orchestrate multiple Claude agents to work together on complex tasks.
   - Cron + heartbeat scheduling, shared task queue with human-escalation gates, Telegram control
   - Babysit and needs-you triage dashboard; self-hosted, MIT
 
+- [beastlabai/multi-llm-plugin](https://github.com/beastlabai/multi-llm-plugin) ![Stars](https://img.shields.io/github/stars/beastlabai/multi-llm-plugin?style=flat-square)
+  - Multi-LLM orchestration plugin for Claude Code
+  - Parallel plan review, task generation, implementation, and code review across 12 coding harnesses (Codex, Cursor, opencode, pi, aider, Antigravity…)
+
 ### Parallel Processing
 
 - [Dicklesworthstone/claude_code_agent_farm](https://github.com/Dicklesworthstone/claude_code_agent_farm) ![Stars](https://img.shields.io/github/stars/Dicklesworthstone/claude_code_agent_farm?style=flat-square)


### PR DESCRIPTION
## What

Adds one entry to **Multi-Agent Systems > Orchestration Platforms**:

[beastlabai/multi-llm-plugin](https://github.com/beastlabai/multi-llm-plugin) — Multi-LLM orchestration plugin for Claude Code: parallel plan review, task generation, implementation, and code review across 12 coding harnesses (Codex, Cursor, opencode, pi, aider, Antigravity…)

## Checklist against the Contributing guidelines

- **Actively maintained** — yes, regular commits (latest within the past week), issues triaged and fixed.
- **Clear documentation** — README with install instructions, a full walkthrough video plus a short intro video, per-provider configuration docs, and an e2e test harness.
- **Real value to Claude users** — installs as a Claude Code plugin (`/plugin`) and lets Claude Code fan a plan or diff out to up to 12 other coding CLIs in parallel and aggregate their reviews/implementations.

## Full disclosure

The repo currently has **8 stars** — it is a young project. Mentioning this upfront so you can judge whether it meets the bar; happy to close and resubmit later if you'd prefer it to mature first.

Entry format matches the surrounding entries (shields.io star badge + indented bullets) and is appended at the end of the subsection, consistent with existing ordering.