### PR TITLE
Add tailtest under Core Development Skills

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -285,6 +285,10 @@ Skills focused on software development, code quality, and engineering workflows.
 
 ### Core Development Skills
 
+- [avansaber/tailtest](https://github.com/avansaber/tailtest) ![Stars](https://img.shields.io/github/stars/avansaber/tailtest?style=flat-square)
+  - Generates and runs adversarial tests on every file the agent edits, via a PostToolUse hook
+  - 8 languages, no commands to run, MIT
+
 - [gyujeongion/claude-code-rootcause](https://github.com/gyujeongion/claude-code-rootcause) ![Stars](https://img.shields.io/github/stars/gyujeongion/claude-code-rootcause?style=flat-square)
   - Turns "never do X" bans into positive process gates
   - Audits your instruction file for ban bloat (rethink + deusex)


### PR DESCRIPTION
Adds **tailtest** under **Core Development Skills**, in the same two-bullet format as the surrounding entries.

tailtest hooks PostToolUse so that every file Claude Code edits gets tested in the same turn: the edited file is queued, production-shaped scenarios are generated through a rule layer, they run against the project's existing test runner, and failures come back to Claude before it moves on. Nothing to invoke.

It sits alongside the verification-gate entries here rather than duplicating them: the gate entries check a change before it lands, tailtest exercises the code that was just written.

- Adversarial generation, biased toward breakage paths rather than happy-path coverage
- 8 languages: Python, TypeScript, JavaScript, Go, Ruby, PHP, Java, Rust
- MIT, no telemetry
- Bugs found and reported upstream in open-source Python repos, with maintainer-merged fixes: https://www.tailtest.com/case-studies/

Repo: https://github.com/avansaber/tailtest