### PR TITLE
Add claude-memory-tidy to Memory & Context Management

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1230,6 +1230,12 @@ Utilities and tools to enhance your Claude workflow.
 
 ### Memory & Context Management
 
+- [tonydzi/claude-memory-tidy](https://github.com/tonydzi/claude-memory-tidy) ![Stars](https://img.shields.io/github/stars/tonydzi/claude-memory-tidy?style=flat-square)
+  - Keeps Claude Code's always-loaded `MEMORY.md` from silently truncating: the harness cuts the tail past a fixed size with no error, so the agent quietly stops knowing things it "remembers"
+  - Deterministic guard (budget, orphaned notes, dead pointers, duplicates, sync-conflicts) plus verbatim folding of a domain into warm `hub-*.md` sub-indexes, so pointers never lose findability
+  - Mechanical work runs with no LLM at all; the model is summoned only when the detectors say there is work, and the guard re-verifies afterwards
+  - Declared per-machine ownership prevents a second writer on an index synced from another machine; macOS/Linux, stdlib only, 17 tests
+
 - [hjqcan/GoodMemory](https://github.com/hjqcan/GoodMemory) ![Stars](https://img.shields.io/github/stars/hjqcan/GoodMemory?style=flat-square)
   - Local-first, auditable memory layer for Claude Code, Codex, and MCP clients
   - One-command `goodmemory setup` installs managed hooks for scoped recall; governed writeback is opt-in, reviewable, and reversible


### PR DESCRIPTION
Adds one resource to **Memory & Context Management**.

### What it is
[claude-memory-tidy](https://github.com/tonydzi/claude-memory-tidy) — a small deterministic toolkit that keeps Claude Code's always-loaded `MEMORY.md` index healthy on macOS/Linux.

### The problem it addresses
`MEMORY.md` is loaded into every session, and past a fixed size the harness truncates it **with no error**. The tail silently disappears and the agent stops knowing things it "remembers". Separately, notes accumulate on disk that nothing points at — present but unreachable, which at recall time is the same as deleted.

### What it does
- **Guard** (no LLM): budget, over-length entries, orphaned notes, dead pointers, duplicate slugs, sync-conflict files.
- **Orphan coverage** (no LLM): gives every unreachable note a pointer in the not-auto-loaded archive, using the note's own `description:` — transcription, not invention, and it costs zero live-index budget.
- **Folding** (no LLM): moves a domain into a warm `hub-*.md` sub-index **verbatim**, and refuses to write at all if any folded note would lose reachability. This guards against summary-grounding, where a model rewrites a hook "while it's in there" and the disambiguating detail evaporates.
- **Tidy runner**: cheap detectors gate the model, so a quiet day costs ~0 tokens; afterwards the guard re-verifies, because the model's own summary of its work is not evidence.
- **Declared ownership**: prevents a second writer on an index synced byte-identically from another machine.

Measured on one real run: 26 275 B / 164 lines / 112 orphans → 8 606 B / 52 lines / 0 orphans. Nothing deleted.

### Checklist
- Actively maintained — yes, in daily use on the machine it was built for
- Clear documentation — README plus an installable `SKILL.md`
- Real value to Claude users — addresses a silent failure mode of always-loaded memory
- One resource, one PR

MIT, Python stdlib only, no network calls, no telemetry. 17 tests run against a temporary fixture (`python3 tests/test_memory_tidy.py`), so they pass on any machine and never touch real memory.