### PR TITLE
Add humanpen-skill under Marketing & Content

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -782,7 +782,7 @@ n- [GiulioDER/cca-audit](https://github.com/GiulioDER/cca-audit) ![Stars](https:
 Skills for marketing professionals, content creators, and growth teams.
 
 - [humanpen/humanpen-skill](https://github.com/humanpen/humanpen-skill) ![Stars](https://img.shields.io/github/stars/humanpen/humanpen-skill?style=flat-square)
-  - Lowers a Word/PowerPoint/PDF document's AI-detection score so it reads as human-written
+  - Document-level AI humanizer for .docx/.pptx — whole file, selected passages, or detector-flagged text
   - Keeps every fact, number, table and all formatting intact
   - The document never enters the model's context — upload, then get a result path back
   - Works with Claude Code, Codex, Cursor, and other SKILL.md clients

--- a/readme.md
+++ b/readme.md
@@ -781,6 +781,12 @@ n- [GiulioDER/cca-audit](https://github.com/GiulioDER/cca-audit) ![Stars](https:
 
 Skills for marketing professionals, content creators, and growth teams.
 
+- [humanpen/humanpen-skill](https://github.com/humanpen/humanpen-skill) ![Stars](https://img.shields.io/github/stars/humanpen/humanpen-skill?style=flat-square)
+  - Lowers a Word/PowerPoint/PDF document's AI-detection score so it reads as human-written
+  - Keeps every fact, number, table and all formatting intact
+  - The document never enters the model's context — upload, then get a result path back
+  - Works with Claude Code, Codex, Cursor, and other SKILL.md clients
+
 - [cognyai/claude-code-marketing-skills](https://github.com/cognyai/claude-code-marketing-skills) ![Stars](https://img.shields.io/github/stars/cognyai/claude-code-marketing-skills?style=flat-square)
   - 5 free marketing skills, no account required
   - SEO Audit, Landing Page Review, Competitor Analysis


### PR DESCRIPTION
Adds [humanpen-skill](https://github.com/humanpen/humanpen-skill).

Lowers a Word/PowerPoint/PDF document's AI-detection score so it reads as human-written, keeping every fact, number, table and all formatting intact. Ships `SKILL.md`; works in Claude Code, Codex, Cursor and other clients; Apache-2.0. (Happy to move it to a better-fit section if you prefer.)