### PR TITLE
Add shut-up-and-code (Core Development Skills)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -442,6 +442,12 @@ Skills focused on software development, code quality, and engineering workflows.
   - Hooks enforce type-checking and lint on edits
   - TypeScript, MIT licensed
 
+- [chl03ks/shut-up-and-code](https://github.com/chl03ks/shut-up-and-code) ![Stars](https://img.shields.io/github/stars/chl03ks/shut-up-and-code?style=flat-square)
+  - Load-bearing comments only: one ships if deleting it costs the reader something the code cannot tell them
+  - Bounds doc comments too — a contract is written when the signature leaves a real question, not because something is exported
+  - Publishes a benchmark with fixtures, prompts and raw outputs, so its effect can be re-measured
+  - Skill plus optional always-on SessionStart hook; MIT licensed
+
 ### Specialized Agents
 
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) ![Stars](https://img.shields.io/github/stars/VoltAgent/awesome-claude-code-subagents?style=flat-square)


### PR DESCRIPTION
Adds [shut-up-and-code](https://github.com/chl03ks/shut-up-and-code) under Development & Engineering → Core Development Skills, following the existing entry format.

A Claude Code plugin that suppresses reflexive commenting: a comment ships only if deleting it would cost a competent reader something the code cannot tell them. Unlike most skills in this space it also bounds doc comments — a contract is written when the signature leaves a genuine question (units, failure modes, ordering, thread safety), not merely because a symbol is exported.

It ships a [benchmark](https://github.com/chl03ks/shut-up-and-code/tree/main/benchmark) with fixtures, scenario prompts, raw outputs across three arms, and the measuring script, so the numbers can be re-run rather than taken on trust. That measurement caught the previous release producing roughly 5x the comment volume of loading no skill at all, which is what the current version fixes.

MIT licensed, no external services.