### PR TITLE
Add alibaba-java-guidelines-skills — Alibaba Java Manual as 8 skills, with PDF-extraction defects fixed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -442,6 +442,12 @@ Skills focused on software development, code quality, and engineering workflows.
   - Hooks enforce type-checking and lint on edits
   - TypeScript, MIT licensed
 
+- [qingtiandamowang/alibaba-java-guidelines-skills](https://github.com/qingtiandamowang/alibaba-java-guidelines-skills) ![Stars](https://img.shields.io/github/stars/qingtiandamowang/alibaba-java-guidelines-skills?style=flat-square)
+  - Alibaba Java Development Manual (Huangshan edition) as 8 skills — all 324 rules
+  - Fixes systematic PDF-extraction defects other ports share: chapter bleed, broken 【强制】/【推荐】markers, page numbers glued to rule text
+  - Schema, security, testing, error-code and design chapters retargeted to ANY language (Go, Rust, Python); Java-only chapters explicitly fenced off
+  - Installable as a Claude Code plugin marketplace, or copy individual skills
+
 ### Specialized Agents
 
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) ![Stars](https://img.shields.io/github/stars/VoltAgent/awesome-claude-code-subagents?style=flat-square)


### PR DESCRIPTION
Adds [alibaba-java-guidelines-skills](https://github.com/qingtiandamowang/alibaba-java-guidelines-skills) under **Development & Engineering → Core Development Skills**.

### What it is

The *Alibaba Java Development Manual (Huangshan edition)* — the de-facto coding standard across much of the Chinese Java ecosystem — split into 8 agent skills covering all 324 rules, each carrying its original 【强制】/【推荐】/【参考】 severity level.

### Why another port

Existing ports mechanically extract the PDF and split by chapter, which leaves systematic defects. This one fixes them:

| Defect | Effect |
|---|---|
| Chapter bleed — every file contained "its own chapter + all later chapters" | The coding-standards file held the entire manual; the design chapter was duplicated 7× |
| Broken severity markers (`【强 制】`, `【强制 】`) | 【强制】 is the manual's core semantic unit — a split marker silently demotes a mandatory rule to prose |
| Page numbers glued to rule text (` 33/51 15.【推荐】…`) | Breaks rule numbering; affected rules become invisible to scanning |
| Lost column separators in the error-code table | Three columns collapsed into one unparseable string |
| Appendices mixed into the design chapter | 69% of that file was version history and error codes, not design rules |

Net: 3993 lines of duplication removed, 324 severity markers repaired, 41 glued page numbers stripped, 2902 PDF spacing artifacts cleaned.

### Cross-language targeting

The manual is written for Java, but several chapters constrain things that are language-independent. Trigger descriptions were rewritten accordingly:

- **Any language** — MySQL schema/index/SQL rules, web security (authz, sanitization, injection, XSS/CSRF, replay, upload), unit-testing discipline, error handling and logging, design principles, and the A/B/C error-code taxonomy
- **Java/Maven only** — the coding-standards and project-structure chapters, which are genuinely Java-specific (POJO, `equals`/`hashCode`, Maven GAV, Tomcat), are explicitly fenced off so they don't fire on Go or Rust work

### Notes

- Rule text is verbatim from the Alibaba manual; copyright belongs to Alibaba Group. This repo only does format conversion, defect repair and restructuring — no rule content was altered. Official source: [alibaba/p3c](https://github.com/alibaba/p3c).
- Conversion work is Apache-2.0, matching p3c.
- Installable as a Claude Code plugin marketplace, or by copying individual skill folders (works with Cursor, Codex and other SKILL.md clients).