### PR TITLE
Add Agent QA MCP and skills

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1488,6 +1488,12 @@ Utilities and tools to enhance your Claude workflow.
   - Drives pages via the structured accessibility tree, not screenshots
   - De facto standard for end-to-end testing and web automation; Apache-2.0 licensed
 
+- [vostride/agent-qa](https://github.com/vostride/agent-qa) ![Stars](https://img.shields.io/github/stars/vostride/agent-qa?style=flat-square)
+  - The self-improving QA agent for software teams
+  - Runs natural-language web and mobile tests with persistent execution memory and self-healing
+  - Ships Claude-compatible Agent Skills plus an stdio MCP server via `agent-qa mcp`
+  - TypeScript; FSL-1.1-ALv2 converting to Apache-2.0 after two years
+
 - [github/github-mcp-server](https://github.com/github/github-mcp-server) ![Stars](https://img.shields.io/github/stars/github/github-mcp-server?style=flat-square)
   - GitHub's official MCP server for repos, issues, PRs, and Actions
   - Offered as a hosted remote server and a local Go binary


### PR DESCRIPTION
## Summary

Adds [vostride/agent-qa](https://github.com/vostride/agent-qa) beside Playwright MCP in **MCP Servers & Integrations**.

The entry records the parts that are directly useful to Claude users:

- natural-language web and mobile tests
- persistent execution memory and self-healing
- three Claude-compatible Agent Skills
- the exact stdio MCP command, `agent-qa mcp`
- the current FSL-1.1-ALv2 license and its two-year Apache-2.0 conversion

Agent QA is actively maintained, has 768 GitHub stars, and provides both [official documentation](https://vostride.com/docs/agent-qa) and source-level skill/MCP documentation.

## Validation

- `git diff --check`
- confirmed the repository, documentation, and canonical skills path resolve
- confirmed the shipped Agent Skills validator passes
- repository-wide `npx --yes awesome-lint` reports 353 structural/format errors and 18 warnings across the list's current conventions; the entry follows the repository's existing nested-bullet format
