### PR TITLE
Add Aeon to Autonomous Development

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1597,6 +1597,11 @@ Utilities and tools to enhance your Claude workflow.
   - Python-based research-grade harness
   - Designed for fast agent-iteration cycles
 
+- [aeonfun/aeon](https://github.com/aeonfun/aeon) ![Stars](https://img.shields.io/github/stars/aeonfun/aeon?style=flat-square)
+  - Autonomous agent framework that runs entirely inside GitHub Actions, with no long-lived server
+  - Cron-scheduled Markdown skills, self-healing (a health skill detects failures, a repair skill fixes them by PR)
+  - Spawns a fleet of clones and ships 70+ Agent Skills across six coding-agent harnesses (Claude Code, Grok, Codex, Pi, Vibe, Kimi)
+
 ### Monitoring & Observability
 
 - [disler/claude-code-hooks-multi-agent-observability](https://github.com/disler/claude-code-hooks-multi-agent-observability) ![Stars](https://img.shields.io/github/stars/disler/claude-code-hooks-multi-agent-observability?style=flat-square)


### PR DESCRIPTION
Adding **[Aeon](https://github.com/aeonfun/aeon)** under **Multi-Agent Systems -> Autonomous Development**.

Aeon is an autonomous agent framework that runs entirely inside GitHub Actions, with no long-lived server. Cron-scheduled Markdown skills self-heal (a health skill detects failures and a repair skill fixes them by PR), spawn a fleet of clones, and ship 70+ Agent Skills across six coding-agent harnesses (Claude Code default, plus Grok, Codex, Pi, Vibe, Kimi).

- Repo: https://github.com/aeonfun/aeon
- License: MIT · 666 stars · actively maintained (daily commits)
- Fits Autonomous Development: it runs unattended on a cron with a self-healing loop, alongside the existing ralph-claude-code and fast-agent entries.

Placed at the end of the Autonomous Development list, single entry, multi-line bullet formatting matches the surrounding entries.