### PR TITLE
Add ZeroPointRepo/youtube-skills to Domain-Specific Skills

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1132,6 +1132,12 @@ Specialized skills for specific industries and use cases.
   - Includes an AI-writing-pattern remover for humanizer-style prose cleanup
   - Apache-2.0 licensed
 
+- [ZeroPointRepo/youtube-skills](https://github.com/ZeroPointRepo/youtube-skills) ![Stars](https://img.shields.io/github/stars/ZeroPointRepo/youtube-skills?style=flat-square)
+  - YouTube transcripts, video search, channel browsing, and playlist extraction from an agent
+  - 12 skills in one repo; install the bundled `youtube-full` for broad coverage or a focused variant for a smaller tool surface
+  - Works with Claude, ChatGPT, OpenClaw, and Hermes Agent through the open Agent Skills format
+  - Free tier, no card required; MIT licensed
+
 ## Productivity Tools
 
 Utilities and tools to enhance your Claude workflow.


### PR DESCRIPTION
Adds **youtube-skills** to Domain-Specific Skills.

YouTube transcripts, video search, channel browsing, and playlist extraction for an agent. 12 skills in one repo; `youtube-full` bundles the common ones, and there are focused variants when you want a smaller tool surface.

- Repo: https://github.com/ZeroPointRepo/youtube-skills (MIT, 520+ stars)
- Open Agent Skills format, so it works with Claude, ChatGPT, OpenClaw, and Hermes Agent
- Free tier, no card required

Format matches the existing entries in the section (link + stars badge + bullets), appended at the end of Domain-Specific Skills.