### PR TITLE
Add simple-man to Core Development Skills

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -442,6 +442,12 @@ Skills focused on software development, code quality, and engineering workflows.
   - Hooks enforce type-checking and lint on edits
   - TypeScript, MIT licensed
 
+- [Maksim-Burtsev/simple-man](https://github.com/Maksim-Burtsev/simple-man) ![Stars](https://img.shields.io/github/stars/Maksim-Burtsev/simple-man?style=flat-square)
+  - Strips praise, recaps and filler from agent answers while keeping every fact you act on
+  - Findings carry location, consequence and one-line fix; refusals carry the safe procedure
+  - Knows when not to compress: tutorials and detailed reports stay long-form
+  - Benchmarked on 1,793 preregistered live calls, raw records committed; MIT licensed
+
 ### Specialized Agents
 
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) ![Stars](https://img.shields.io/github/stars/VoltAgent/awesome-claude-code-subagents?style=flat-square)


### PR DESCRIPTION
Adds [simple-man](https://github.com/Maksim-Burtsev/simple-man): a communication policy that strips praise, recaps and filler from agent answers while keeping every fact you act on.

If you read agent output for hours a day, most of what you read is not work — praise for your question, apologies, recaps of what just happened, three paragraphs around one test. This removes that without losing anything you act on: every review or security finding carries its location, consequence and one-line fix; a refusal names the target, the missing precondition and the safe procedure; a failed check reports the exact failure.

It also knows when *not* to compress — tutorials, teaching explanations and detailed reports are written in full.

Measured rather than claimed: two preregistered runs on `claude-sonnet-5`, 1,793 live calls, all raw records committed — median answer 833 → 520 tokens (−32.4%) with required-fact retention equal to the no-policy baseline. Every published number is rebuilt from the raw records in CI.

Works with Claude Code, Codex, Gemini CLI, Cursor and any AGENTS.md agent. MIT. Entry follows the existing bullet format with a stars badge.