### PR TITLE
Add ZeroPointRepo/zillow-skills to Domain-Specific Skills

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1128,6 +1128,13 @@ Specialized skills for specific industries and use cases.
   - Systematic literature review through slide generation
   - Includes GitHub repository analysis for research topics
 
+- [ZeroPointRepo/zillow-skills](https://github.com/ZeroPointRepo/zillow-skills) ![Stars](https://img.shields.io/github/stars/ZeroPointRepo/zillow-skills?style=flat-square)
+  - Zestimates, comps, for-sale, sold and rental listings, price history, photos, taxes, and schools for 160M+ US homes
+  - 3 skills in one repo; install the bundled `zillow-full` for broad coverage or a focused variant for a smaller tool surface
+  - Works with Claude, ChatGPT, OpenClaw, and Hermes Agent through the open Agent Skills format
+  - Pure Python standard library with no dependencies; free tier, no card required; MIT-0 licensed
+  - Independent service for Zillow-sourced data, not affiliated with or endorsed by Zillow
+
 - [boraoztunc/skills](https://github.com/boraoztunc/skills) ![Stars](https://img.shields.io/github/stars/boraoztunc/skills?style=flat-square)
   - Claude Code skills for copywriting, SEO, and design
   - Includes an AI-writing-pattern remover for humanizer-style prose cleanup


### PR DESCRIPTION
Adds `ZeroPointRepo/zillow-skills` to **Domain-Specific Skills**.

Agent skills for US residential property data: Zestimates, comps, for-sale, sold and rental listings, price history, photos, taxes, and schools across 160M+ homes. There is no real-estate or property-data entry in the list yet, so this fills a gap rather than overlapping an existing one.

Against the contributing checklist:

1. **Actively maintained** - last push 2026-08-16, MIT-0 licensed.
2. **Clear documentation** - README covers install for three runtimes, a skills table, authentication, pricing, and API reference links; repo also ships `CONTRIBUTING.md` and `SECURITY.md`.
3. **Real value** - 3 skills (`zillow-full`, `zillow-zestimate`, `zillow-search`); install the bundle for broad coverage or a focused variant to keep the tool surface small. Pure Python standard library, no dependencies. Free tier with no card required.
4. Entry follows the existing block format in the section, with the standard stars badge.

Zillapi is an independent service for Zillow-sourced data, not affiliated with or endorsed by Zillow. Noted in the entry itself so the listing does not read as official.

Inserted ahead of the `boraoztunc/skills` block rather than at the very end of the section, to avoid a merge conflict with my other open PR (#158) which appends at the section tail. Both apply cleanly in either order.