### PR TITLE
Add ai-tell-detector (Marketing & Content)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -917,6 +917,13 @@ Skills for marketing professionals, content creators, and growth teams.
   - Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, and comment
   - Custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf
 
+- [aragossa/ai-tell-detector](https://github.com/aragossa/ai-tell-detector) ![Stars](https://img.shields.io/github/stars/aragossa/ai-tell-detector?style=flat-square)
+  - Audits a finished draft for the patterns that make text read as AI-generated (24 checks, MIT)
+  - Flags rhetorical symmetry, filler transitions, uniform sentence rhythm, canned CTAs, and em-dash overload
+  - Also catches fabricated personal experience, which is a factual problem rather than a stylistic one
+  - Reports patterns with line numbers and a suggested fix instead of a single confidence score
+  - English and Russian versions included
+
 ---
 
 ## Domain-Specific Skills


### PR DESCRIPTION
Adds [aragossa/ai-tell-detector](https://github.com/aragossa/ai-tell-detector) to **Marketing & Content**.

A free, MIT-licensed Claude skill that audits a finished draft for the patterns that make text read as AI-generated, and flags each one with the line it is on plus a suggested fix. 24 checks, English and Russian versions included.

How it differs from the AI-writing entries already listed: [humanpen/humanpen-skill](https://github.com/humanpen/humanpen-skill) rewrites documents to humanize them, whereas this one is an audit pass that leaves the text alone and reports what to change and where. It also checks for fabricated personal experience, which is a factual problem rather than a stylistic one, and it deliberately reports patterns with line numbers instead of a single confidence score, because external detector scores on the same text can spread 60+ points between tools.

Format follows the existing entries in that section (repo link, stars badge, bullet summary). One resource, one PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)