### PR TITLE
Add SandBase Skills collection

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,12 @@ These repositories offer extensive collections of skills across multiple domains
   - Covers code review and ship grading, design, marketing, agent workflows, and mobile release preparation
   - Installable through the Claude and Codex plugin marketplaces or the skills CLI
 
+- [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills) ![Stars](https://img.shields.io/github/stars/sandbaseai/sandbase-skills?style=flat-square)
+  - 88 Apache-2.0 Agent Skills for research, social intelligence, marketing, and business workflows
+  - Works with Claude Code, Codex, Cursor, Gemini CLI, and DeepSeek Harness
+  - Includes an offline validator and worked evidence-ledger example for multi-source research
+  - Installable through the skills CLI or as a native Claude Code marketplace plugin
+
 - [Claude Code Skills 中文精选集](https://claude-skills.bt199.com/)
   - Chinese directory for Claude Code Skills, agents, and plugins
   - 140+ curated resources for Chinese-speaking developers


### PR DESCRIPTION
## What changed

Add SandBase Skills to the comprehensive skill collections section with its supported agents, installation options, license, and evidence-validation feature.

## Why

The repository contains 88 installable Agent Skills rather than demos. Its flagship multi-source research Skill works with host-provided tools, ships an offline evidence-ledger validator and a complete worked example, and is indexed on skills.sh.

## Validation

- `git diff --check`
- Verified repository activity, Apache-2.0 license, and current star count through the GitHub API
- Verified Skill discovery using `npx --yes skills add sandbaseai/sandbase-skills@multi-source-search --list`

Disclosure: I am contributing this listing on behalf of the SandBase project.
