### PR TITLE
Add kgai to Memory & Context Management

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1243,6 +1243,12 @@ Utilities and tools to enhance your Claude workflow.
 
 ### Memory & Context Management
 
+- [kgaidev/kgai](https://github.com/kgaidev/kgai) ![Stars](https://img.shields.io/github/stars/kgaidev/kgai?style=flat-square)
+  - Immutable append-only decision log for Claude Code, recording why the team chose what it chose
+  - Rejected approaches stay in history with the reason they failed, so an agent does not re-propose a path the team already ruled out
+  - Optional team sync writes to an S3 bucket you own, where parallel writers cannot produce a textual conflict and contradictory decisions surface as branches to resolve
+  - Records structural decisions, not session transcripts or codebase search. No daemon, no server, MIT
+
 - [hjqcan/GoodMemory](https://github.com/hjqcan/GoodMemory) ![Stars](https://img.shields.io/github/stars/hjqcan/GoodMemory?style=flat-square)
   - Local-first, auditable memory layer for Claude Code, Codex, and MCP clients
   - One-command `goodmemory setup` installs managed hooks for scoped recall; governed writeback is opt-in, reviewable, and reversible


### PR DESCRIPTION
Adds one entry to Memory & Context Management, in the same shape as the surrounding items (repo link, stars badge, four sub-bullets).

kgai is an MIT-licensed CLI and Claude Code plugin that records engineering decisions as an immutable append-only log, so an agent can answer "why is this like this" from the team's own history. Rejected approaches stay in the log with the reason they failed. Team sync is opt-in and writes to an S3 bucket you own. No daemon and no server. Install is two commands.

One thing I kept out of the entry: the benchmark figure we quote elsewhere (1M decisions, roughly 100 ms) is a decision lookup specifically, not recall or free-text search, which are slower, so it seemed easier to leave out than to caveat in one line.

Disclosure: we build kgai, so this is a self-submission. Happy to shorten it, move it to a different section, or close this if it is not a fit.