### PR TITLE
Add awesome-claude-code-hooks to the list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -165,6 +165,10 @@ These repositories offer extensive collections of skills across multiple domains
   - Tagged for agentic coding and AI workflow optimization
   - Frequently referenced as a starting point for Claude Code newcomers
 
+- [loqimean/awesome-claude-code-hooks](https://github.com/loqimean/awesome-claude-code-hooks) ![Stars](https://img.shields.io/github/stars/loqimean/awesome-claude-code-hooks?style=flat-square)
+  - Curated list of hooks, guides, and tools for Claude Code hooks
+  - Covers PreToolUse, PostToolUse, SessionStart, Notification, Stop, and more
+
 - [ComposioHQ/awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) ![Stars](https://img.shields.io/github/stars/ComposioHQ/awesome-claude-skills?style=flat-square)
   - Composio-curated directory of Claude Skills, plugins, and workflow integrations
   - Covers agent skills, MCP servers, Claude Code, Codex, Cursor, Gemini CLI, and Antigravity


### PR DESCRIPTION
Adds a link to loqimean/awesome-claude-code-hooks, a curated list of hooks, guides, and tools for Claude Code hooks (PreToolUse, PostToolUse, SessionStart, Notification, Stop, and more).

Added it to the Comprehensive Skill Collections section near the other awesome-list style repos, since it's a focused companion list for hooks specifically.