### PR TITLE
Add chamnan to Core Development Skills

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -285,6 +285,13 @@ Skills focused on software development, code quality, and engineering workflows.
 
 ### Core Development Skills
 
+- [ArcticFox2029/chamnan](https://github.com/ArcticFox2029/chamnan) ![Stars](https://img.shields.io/github/stars/ArcticFox2029/chamnan?style=flat-square)
+  - Builds an architecture index the agent reads instead of scanning files
+  - Keeps work state and the decisions behind the code across sessions, so an agent stops rediscovering them
+  - Records the procedures and traps you keep re-deriving, and notices when one repeats
+  - Warns before a read pulls in a lock file or a minified bundle; redacts secrets from everything it writes
+  - Python standard library only — no packages, no network, nothing leaves the machine
+
 - [musoyangrigor/gitx-skill](https://github.com/musoyangrigor/gitx-skill) ![Stars](https://img.shields.io/github/stars/musoyangrigor/gitx-skill?style=flat-square)
   - Turns messy AI-generated changes into clean, reviewable Git history
   - Splits mixed working-tree changes into logical Conventional Commits


### PR DESCRIPTION
One entry, in the format the section already uses.

**[chamnan](https://github.com/ArcticFox2029/chamnan)** — an agent starts every session not knowing the repository, so the first turns go on rediscovering the architecture, the reasons behind past decisions, and the traps already hit. chamnan scans the repo once into an architecture index and injects a few thousand tokens of it at session start, keeps the work state and decisions that would otherwise be lost between sessions, and accumulates the procedures you keep re-deriving.

Eight skills (`/chamnan:bootstrap`, `remap`, `capture`, `promote`, `remember`, `resume`, `milestone`, `report`), four hooks, two subagents.

### Numbers, and where to check them

On a 529-file polyglot corpus: 1,373,242 tokens of source become a 53,646-token index, of which about 3,000 reach each session. The impact map stays out of the injection entirely and is grepped when needed.

The corpus is published rather than described — [chamnan-corpus](https://github.com/ArcticFox2029/chamnan-corpus), 800 files across 72 file types with comments in eight writing systems. Clone it and the figures reproduce, including the one that matters more than the ratio: none of its 28 planted credentials appear in the generated index.

### Fit for this section

- **Runs and is tested** — 378 checks, `python3 tests/run_tests.py`, no pytest
- **Python 3.8+, standard library only** — no packages, no network, no account, no telemetry; nothing leaves the machine and the README says the plugin will never have any
- **MIT**, maintained, `claude plugin validate --strict` clean

A Kiro build exists at [chamnan-kiro](https://github.com/ArcticFox2029/chamnan-kiro) for anyone on that editor; this entry is the Claude Code one.
