### PR TITLE
Add claude-wol-remote-access to Domain-Specific Skills

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1140,6 +1140,14 @@ Specialized skills for specific industries and use cases.
   - Includes an AI-writing-pattern remover for humanizer-style prose cleanup
   - Apache-2.0 licensed
 
+- [REMvisual/claude-wol-remote-access](https://github.com/REMvisual/claude-wol-remote-access) ![Stars](https://img.shields.io/github/stars/REMvisual/claude-wol-remote-access?style=flat-square)
+  - Guided setup for a phone-reachable Wake-on-LAN and remote power panel over Tailscale
+  - Explains why Wake-on-LAN cannot cross a tailnet (the magic packet is a layer-2 broadcast) and builds a relay on an always-on device such as a NAS or Raspberry Pi
+  - Live vitals per machine: GPU temperature, utilisation, VRAM, power and fan, plus CPU, RAM, uptime, disks, and which model is loaded on the GPU
+  - Ships a magic-packet listener that proves whether a packet actually arrived, separating network faults from firmware faults
+  - Symptom-first troubleshooting reference covering Wake-on-LAN, SSH, BIOS access, and NAS relay hosts
+  - MIT licensed; invoked as `/wake-panel`
+
 ## Productivity Tools
 
 Utilities and tools to enhance your Claude workflow.


### PR DESCRIPTION
Adds one entry to **Domain-Specific Skills**.

**Disclosure:** this is my own project, and the PR was prepared with Claude Code.

### What it is

[REMvisual/claude-wol-remote-access](https://github.com/REMvisual/claude-wol-remote-access) — a Claude Code skill that sets up a password-protected web panel on an always-on device (NAS, Raspberry Pi, mini-PC) to wake, monitor and power your machines from a phone over Tailscale.

The core problem it addresses: a Wake-on-LAN magic packet is a layer-2 broadcast and Tailscale is layer 3, so no phone app can wake a PC over a tailnet. The packet has to originate on the LAN, which is why a relay is needed.

### Why it fits the list

- More than a single `SKILL.md`: 16 files including a standard-library Python relay, Windows and Linux telemetry collectors, and a 633-line symptom-first troubleshooting reference.
- Not a SaaS wrapper. Nothing calls a hosted service; it runs entirely on the user hardware, no accounts, no pip/npm/database.
- MIT licensed. Install script and flat release zip both provided and tested end to end.

### Checks

- No duplicate entry — searched the readme for wake-on-lan / WoL / remote power / magic packet.
- Entry format matches the surrounding multi-bullet entries in the same section.
- Single item, single PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)