### PR TITLE
Add Famulor Assistants & History skill

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1389,6 +1389,11 @@ Utilities and tools to enhance your Claude workflow.
 
 ### MCP Servers & Integrations
 
+- [bekservice/Famulor-Skill](https://github.com/bekservice/Famulor-Skill) ![Stars](https://img.shields.io/github/stars/bekservice/Famulor-Skill?style=flat-square)
+  - Agent Skill for operating Famulor assistants, calls, messaging, campaigns, knowledge, dashboards, automations, settings, and tasks through remote MCP
+  - Uses progressive tool discovery for a 282-tool catalog across 13 toolsets
+  - Includes Claude, Cursor, and generic agent-plugin manifests; MCP access uses browser-based OAuth
+
 - [oraios/serena](https://github.com/oraios/serena) ![Stars](https://img.shields.io/github/stars/oraios/serena?style=flat-square)
   - Powerful coding agent toolkit with semantic capabilities
   - MCP server for retrieval and editing

--- a/readme.md
+++ b/readme.md
@@ -1389,10 +1389,10 @@ Utilities and tools to enhance your Claude workflow.
 
 ### MCP Servers & Integrations
 
-- [bekservice/Famulor-Skill](https://github.com/bekservice/Famulor-Skill) ![Stars](https://img.shields.io/github/stars/bekservice/Famulor-Skill?style=flat-square)
-  - Agent Skill for operating Famulor assistants, calls, messaging, campaigns, knowledge, dashboards, automations, settings, and tasks through remote MCP
-  - Uses progressive tool discovery for a 282-tool catalog across 13 toolsets
-  - Includes Claude, Cursor, and generic agent-plugin manifests; MCP access uses browser-based OAuth
+- [bekservice/Famulor-Skill](https://github.com/bekservice/Famulor-Skill/tree/main/claude-store/skills/famulor-assistants-history) ![Stars](https://img.shields.io/github/stars/bekservice/Famulor-Skill?style=flat-square)
+  - Read-only Agent Skill for reviewing Famulor assistant configurations and omnichannel call, messaging, and email history
+  - Uses exactly 11 list/get tools with the restricted `assistants:read` and `calls:read` OAuth scopes
+  - Includes connected-channel history such as WhatsApp and Instagram when the authenticated workspace returns it
 
 - [oraios/serena](https://github.com/oraios/serena) ![Stars](https://img.shields.io/github/stars/oraios/serena?style=flat-square)
   - Powerful coding agent toolkit with semantic capabilities


### PR DESCRIPTION
## Summary

Adds the first-party Famulor Assistants & History skill to **MCP Servers & Integrations**.

The entry intentionally links the restricted public skill:
https://github.com/bekservice/Famulor-Skill/tree/main/claude-store/skills/famulor-assistants-history

It documents exactly 11 read-only list/get tools, browser OAuth scopes `assistants:read` and `calls:read`, and connected-channel history such as WhatsApp and Instagram only when returned by the authenticated workspace. It does not advertise the separate full developer skill.

## Validation

- Confirmed no existing Famulor entry or PR before preparation.
- Deep skill link and raw `SKILL.md` return HTTP 200.
- Source table contains exactly 11 list/get tools.
- `git diff --check` passed.
- Diff is limited to the Famulor entry in `readme.md`.

Disclosure: first-party submission by BEK Service GmbH, the Famulor publisher. The linked skill repository is MIT-licensed. The hosted MCP server is proprietary/source-available; no open-source license claim is made for it.