### PR TITLE
Add verified-memory-vault to Memory & Context Management

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1387,6 +1387,13 @@ Utilities and tools to enhance your Claude workflow.
   - Builds memory and injects relevant context back into the session
   - From Letta AI; TypeScript, MIT licensed
 
+- [secondbrainstarter/verified-memory-vault](https://github.com/secondbrainstarter/verified-memory-vault) ![Stars](https://img.shields.io/github/stars/secondbrainstarter/verified-memory-vault?style=flat-square)
+  - Free Obsidian vault that gives Claude Code, Codex, and Gemini CLI a persistent Markdown memory with a boot file (`CLAUDE.md`), dated append-only `MEMORY.md`, and daily session notes
+  - `memory_check.py` verifies memory health each session: undated entries, duplicates, dead wikilinks, and MEMORY.md bloat against a line budget, with a score and exit code
+  - `memory_guard.py` is an optional git pre-commit hook that refuses commits deleting many memory files or removing MEMORY.md lines without archiving them first
+  - Standard-library Python only, no Node/npm/plugins; unzip and open in Obsidian, setup under 10 minutes
+
+
 ### MCP Servers & Integrations
 
 - [oraios/serena](https://github.com/oraios/serena) ![Stars](https://img.shields.io/github/stars/oraios/serena?style=flat-square)


### PR DESCRIPTION
Adds [Verified Memory Vault](https://github.com/secondbrainstarter/verified-memory-vault) to the **Memory & Context Management** section.

What it is: a free Obsidian vault that gives coding agents (Claude Code, Codex, Gemini CLI) a persistent Markdown memory — boot file (`CLAUDE.md`), dated append-only `MEMORY.md`, daily session notes — plus two stdlib-Python tools: `memory_check.py` scores memory hygiene (undated entries, duplicates, dead wikilinks, budget bloat) and `memory_guard.py` is an optional pre-commit hook that refuses mass deletions or MEMORY.md history rewrites.

Why it fits this section: the entries here cover memory backends and context layers; this one covers the failure modes those layers don't — verifying that the memory is still healthy and protecting it from the agent's own cleanup commits. No Node/npm/plugins; unzip and open in Obsidian.

Single-file addition (7 lines, new entry at the end of the section, no existing lines touched). Happy to adjust wording or position.