### PR TITLE
Add punchcard to Core Development Skills

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -442,6 +442,14 @@ Skills focused on software development, code quality, and engineering workflows.
   - Hooks enforce type-checking and lint on edits
   - TypeScript, MIT licensed
 
+- [Maksim-Burtsev/punchcard](https://github.com/Maksim-Burtsev/punchcard) ![Stars](https://img.shields.io/github/stars/Maksim-Burtsev/punchcard?style=flat-square)
+  - Architecture-level review of a working tree, branch, or pull request
+  - Three independent search passes merged into one verdict, one card per finding
+  - Every blocker demonstrated by running the code on both branches, never asserted
+  - Every finding cites one of 78 principles distilled from thirty engineering books
+  - Says nothing about naming or formatting; MIT licensed
+  - Works in Claude Code, Codex, Cursor, Gemini CLI and other Agent Skills hosts
+
 ### Specialized Agents
 
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) ![Stars](https://img.shields.io/github/stars/VoltAgent/awesome-claude-code-subagents?style=flat-square)


### PR DESCRIPTION
Adding my skill **[punchcard](https://github.com/Maksim-Burtsev/punchcard)** to *Core Development Skills*.

It reviews a working tree, a branch or a pull request at the architecture level — module boundaries, dependency direction, the data model, error paths, the cost of the next change — and deliberately says nothing about naming or formatting.

Two things make it different from the review skills already in the section:

- **A constitution instead of vibes.** Thirty classic software books, read cover to cover and distilled into 349 principles, then into the 78 that decide a review. Every finding cites the principle it rests on, so the reasoning is arguable rather than the tone. The shelf, the distillations and the decided conflicts between authors are all published in the repo.
- **Blockers are demonstrated, not asserted.** Three independent search passes run as subagents, then a single judge verifies each candidate by actually running the code on both branches. What it can't reproduce, it doesn't report. Back comes the same shape every time: one verdict, a summary table, one card per finding.

Installs as a standard Agent Skill — `npx skills add Maksim-Burtsev/punchcard` — so it works in Claude Code, Codex, Cursor, Gemini CLI and other hosts. There is also a Claude Code plugin with `/punchcard` and `/punchcard:pr`, which posts the review into a GitHub PR or GitLab MR.

Actively maintained, MIT, currently v1.4.0, with a README covering install, usage and the benchmark runs. Entry follows the surrounding badge-plus-bullets format. Thanks for maintaining the list!
