### PR TITLE
Add VidWords YouTube MCP server

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1526,6 +1526,12 @@ Utilities and tools to enhance your Claude workflow.
   - Query databases and create/update pages and blocks via the Notion API
   - Supports a hosted remote endpoint and local stdio deployment
 
+- [haljishi/vidwords-mcp](https://github.com/haljishi/vidwords-mcp) ![Stars](https://img.shields.io/github/stars/haljishi/vidwords-mcp?style=flat-square)
+  - Hosted YouTube MCP server: search transcripts, read captions, analyse a video's frames
+  - `search_transcript` takes a list of videos, so one call answers a question across a channel
+  - Every answer carries a clickable timestamp citation rather than a wall of transcript
+  - Remote Streamable HTTP with OAuth 2.1; official registry id `com.vidwords/youtube`
+
 ### API & Integration Tools
 
 - [router-for-me/CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) ![Stars](https://img.shields.io/github/stars/router-for-me/CLIProxyAPI?style=flat-square)


### PR DESCRIPTION
### What this adds

One entry at the end of **Productivity Tools → MCP Servers & Integrations**.

```
- [haljishi/vidwords-mcp](https://github.com/haljishi/vidwords-mcp) ![Stars](...)
  - Hosted YouTube MCP server: search transcripts, read captions, analyse a video's frames
  - search_transcript takes a list of videos, so one call answers a question across a channel
  - Every answer carries a clickable timestamp citation rather than a wall of transcript
  - Remote Streamable HTTP with OAuth 2.1; official registry id com.vidwords/youtube
```

### Why it fits here

Same shape as the Firecrawl and Notion rows already in the section: a hosted MCP server with an official registry listing, usable from Claude Code, Claude Desktop, Cursor and Codex. The repo carries the README, `server.json`, ready-made client configs for all four, and an agent skill under `skills/youtube-transcripts/`.

Nine tools: `search_transcript`, `get_transcript`, `list_channel_videos`, `analyze_video`, `get_analysis`, `ask_video`, `list_watchlists`, `watchlist_activity`, `account`. Connection is OAuth 2.1 with dynamic client registration and PKCE, so there is nothing to paste; a static token remains available for CI and headless agents.

Format matches the surrounding entries exactly — repo link, stars badge, four short bullets.

### Disclosure

I maintain this. Free tier included, no card required.
