### PR TITLE
Add publishport-skill (Marketing & Content)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -924,6 +924,12 @@ Skills for marketing professionals, content creators, and growth teams.
   - Reports patterns with line numbers and a suggested fix instead of a single confidence score
   - English and Russian versions included
 
+- [karuha-m/publishport-skill](https://github.com/karuha-m/publishport-skill) ![Stars](https://img.shields.io/github/stars/karuha-m/publishport-skill?style=flat-square)
+  - Publish and cross-post to 60+ social and content platforms through your own logged-in browser (MIT)
+  - Reaches platforms with no public write API — Xiaohongshu, Douyin, Zhihu, WeChat — alongside X, Reddit, LinkedIn, Medium and Bluesky
+  - No platform API keys: commands run on your own machine, in your own session
+  - Guards the risky parts — verify the account first, stage long text as files, confirm a post landed instead of retrying blind
+
 ---
 
 ## Domain-Specific Skills

--- a/readme.md
+++ b/readme.md
@@ -929,6 +929,7 @@ Skills for marketing professionals, content creators, and growth teams.
   - Reaches platforms with no public write API — Xiaohongshu, Douyin, Zhihu, WeChat — alongside X, Reddit, LinkedIn, Medium and Bluesky
   - No platform API keys: commands run on your own machine, in your own session
   - Guards the risky parts — verify the account first, stage long text as files, confirm a post landed instead of retrying blind
+  - Install with `npx skills add karuha-m/publishport-skill` (Claude Code, Cursor, Codex, Copilot, Gemini and 70+ others)
 
 ---
 


### PR DESCRIPTION
Adding [karuha-m/publishport-skill](https://github.com/karuha-m/publishport-skill) under **Marketing & Content**.

The existing publishing entries in this section wrap a SaaS relay or a platform API, which caps them at platforms that expose a public write API. This one runs the commands on the user's own machine, in their own logged-in browser, so it also reaches platforms that have no public write API at all — Xiaohongshu, Douyin, Zhihu, WeChat — alongside X, Reddit, LinkedIn, Medium and Bluesky. No API keys to provision.

The skill body is the workflow and its guardrails: verify the account is signed in, read each platform's real command schema rather than guessing flags, stage long text and media as files, show the user the post before it goes out, and confirm it landed instead of blindly retrying and double-posting.

MIT licensed, installable as a Claude Code plugin, a plain `SKILL.md`, or a zip for claude.ai.