### PR TITLE
Add UiPath/coder_eval to Agent Harnesses & Meta-Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1248,6 +1248,12 @@ Utilities and tools to enhance your Claude workflow.
   - MCP stdio server plus an OpenAI-compatible proxy (`:8077/v1`); one-command installer wires 18 coding agents including Claude Code, Codex, Cursor, and Windsurf
   - MIT licensed, Python 3.11; early-stage (v0.1.0, released 2026-07-06)
 
+- [UiPath/coder_eval](https://github.com/UiPath/coder_eval) ![Stars](https://img.shields.io/github/stars/UiPath/coder_eval?style=flat-square)
+  - Measures whether a skill actually triggers: precision, recall, and F1 over labelled prompt datasets
+  - Runs one task suite across Claude Code, Codex, OpenCode, and Antigravity to separate skill defects from harness defects
+  - Sandboxed runs, LLM-judge and deterministic criteria, published GitHub Action for CI gating
+  - Python, Apache-2.0
+
 ### Memory & Context Management
 
 - [hjqcan/GoodMemory](https://github.com/hjqcan/GoodMemory) ![Stars](https://img.shields.io/github/stars/hjqcan/GoodMemory?style=flat-square)


### PR DESCRIPTION
Adds **UiPath/coder_eval** to `Agent Harnesses & Meta-Tools`.

**Disclosure:** I maintain this project. Happy to reword, trim the sub-bullets, or move it — `Development & Engineering` would also be defensible if you read it that way.

### Why this section

The section already holds tools that sit *around* the agent rather than inside it — `ruler` normalising rules across harnesses, `oh-my-openagent` orchestrating them. coder_eval is the measurement counterpart: it runs one labelled task suite across Claude Code, Codex, OpenCode and Antigravity and reports how each one did, which is what makes "the skill is broken" separable from "that harness never routed to it."

The specific thing it measures is skill **activation** — does a skill actually fire on the prompts it claims to handle, and stay quiet on the ones it doesn't. That comes out as precision / recall / F1 over a labelled dataset, and it can gate CI on those numbers via a published GitHub Action.

### Against your four criteria

1. **Actively maintained** — last commit today; releases on PyPI, current 0.11.4.
2. **Clear documentation** — https://coder-eval.com/docs, plus a task-definition guide and tutorials.
3. **Real value** — skill and plugin authors currently have no way to tell whether a `description:` edit helped or hurt activation. This measures it.
4. **Production-ready, not experimental** — Apache-2.0, 118★, its own CI runs the suites on every PR and dogfoods the published Action.

I followed the section's existing shape (repo link + stars badge + short sub-bullets, language named last). Cut any sub-bullet you find redundant.
