### PR TITLE
Add d1v deployment Skill

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -442,6 +442,11 @@ Skills focused on software development, code quality, and engineering workflows.
   - Hooks enforce type-checking and lint on edits
   - TypeScript, MIT licensed
 
+- [d1vai/d1v-cli](https://github.com/d1vai/d1v-cli) ![Stars](https://img.shields.io/github/stars/d1vai/d1v-cli?style=flat-square)
+  - Official d1v Skill for deployment workflows in Claude Code and Codex
+  - Waits for verified preview deployments and reports terminal deployment status
+  - Production releases require an interactive TTY and explicit user confirmation; MIT licensed
+
 ### Specialized Agents
 
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) ![Stars](https://img.shields.io/github/stars/VoltAgent/awesome-claude-code-subagents?style=flat-square)


### PR DESCRIPTION
## Summary

Adds the official [d1v Skill](https://github.com/d1vai/d1v-cli/blob/main/skills/d1v/SKILL.md) to **Development & Engineering / Core Development Skills**.

## Why it fits

The Skill provides an agent-facing deployment workflow for AI-built web projects: it waits for a verified preview terminal state, exposes deployment status, and requires an interactive TTY plus explicit user confirmation for production releases.

## Source and disclosure

- Public source: `d1vai/d1v-cli`, MIT licensed
- Canonical source file: `skills/d1v/SKILL.md`
- Supported hosts documented by the project: Claude Code and Codex
- Submitted on behalf of the d1v project

## Validation

- verified the public source, license, and canonical Skill path
- confirmed no existing d1v entry or open PR
- matched the surrounding multi-line entry format
- ran `git diff --check`

This is a one-file documentation change; no target-project dependencies, builds, or tests were run.