### PR TITLE
Add Backbrief Kit to Orchestration Platforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -537,6 +537,12 @@ Orchestrate multiple Claude agents to work together on complex tasks.
 
 ### Orchestration Platforms
 
+- [charlesashe/backbrief-kit](https://github.com/charlesashe/backbrief-kit) ![Stars](https://img.shields.io/github/stars/charlesashe/backbrief-kit?style=flat-square)
+  - Orchestrator decomposes a goal into units with acceptance criteria and routes each to a specialist agent
+  - A separate verifier re-reads the finished artifact in fresh context, never the producing agent's reasoning, before work is called done
+  - Shared rules every agent obeys: it stops before spending, sending, publishing, or granting access rather than acting alone
+  - Opt-in SessionStart hook re-injects the newest handoff brief and decision-log tail after startup, /clear, and compaction
+
 - [supernovae-st/nika](https://github.com/supernovae-st/nika) ![Stars](https://img.shields.io/github/stars/supernovae-st/nika?style=flat-square)
   - Workflow engine for AI: Claude Code captures repeatable work as `.nika.yaml` DAG files
   - Statically checked before execution (schema, permits, cost floor), tamper-evident traces after


### PR DESCRIPTION
Adds one entry under **Multi-Agent Systems > Orchestration Platforms**, in the existing bullet format with the stars badge.

**What it is:** a multi-agent framework for Claude Code, delivered as plain Markdown. An orchestrator decomposes a goal into units with acceptance criteria and routes each to the specialist that fits it; a separate verifier then reviews the finished artifact in fresh context — it receives the artifact and criteria only, never the producing agent's reasoning — before the work is called done. A rules layer applies to every agent, including the guardrail that stops the team before it spends, sends, publishes, or grants access. An opt-in `SessionStart` hook re-injects the newest handoff brief and decision-log tail, so a fresh chat and a post-compaction context both start knowing where the project stands.

**Install:** `/plugin marketplace add charlesashe/backbrief-kit` then `/plugin install backbrief-kit@backbrief`.

**Against your quality bar:** actively maintained (last commit 2026-08-26), documented in the repo README and at backbrief.ai, and it is what I run my own projects on daily. Free to use. One thing to flag honestly rather than have you find it: the license is source-available and custom, not OSI — use, modification for your own use, and unmodified free sharing are permitted; resale is not. Happy to move the entry to another section if Orchestration Platforms is not where you would file it.