### PR TITLE
Add trailhead to Core Development Skills

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -442,6 +442,12 @@ Skills focused on software development, code quality, and engineering workflows.
   - Hooks enforce type-checking and lint on edits
   - TypeScript, MIT licensed
 
+- [ToRvaLDz/trailhead](https://github.com/ToRvaLDz/trailhead) ![Stars](https://img.shields.io/github/stars/ToRvaLDz/trailhead?style=flat-square)
+  - Runs a project too large for one session as a map of decision tickets on GitHub Issues
+  - discuss→plan→execute→verify engine: grilling, throwaway prototypes, TDD, cross-AI plan review, adversarial code review, goal-backward verification
+  - Atomic commits; the map, discussions, plans, and verifications all live on the Issues, not in the session context
+  - Self-contained (ships its own trailhead-* agents); works on Claude Code and Codex
+
 ### Specialized Agents
 
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) ![Stars](https://img.shields.io/github/stars/VoltAgent/awesome-claude-code-subagents?style=flat-square)


### PR DESCRIPTION
Adds **trailhead** under *Development & Engineering → Core Development Skills*, alongside its closest analogs (Superpowers, mattpocock/skills, claude-code-spec-workflow).

**What it is:** a Claude Code plugin/skill that runs a project too large for one session as a map of decision tickets on GitHub Issues, resolved one at a time via a discuss→plan→execute→verify engine (grilling, throwaway prototypes, TDD, cross-AI plan review, adversarial code review, goal-backward verification) with atomic commits. The whole plan (map, discussions, plans, verifications) lives on the Issues rather than in the session context. Self-contained (ships its own trailhead-* engine agents) and runs on both Claude Code and Codex.

**Meets the contribution bar:**
- Actively maintained: published on npm as `@marcomigozzi/trailhead` (v0.6.0, latest), with a live site + docs at trailhead.marcomigozzi.it.
- Clear documentation: README + a full /docs section.
- Real value: an end-to-end planning/execution engine for large projects, distinct from single-purpose skills.

MIT licensed.