### PR TITLE
Update suede-creator-skills count and license in Comprehensive Skill Collections

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -105,7 +105,7 @@ These repositories offer extensive collections of skills across multiple domains
   - Compatible with 11 different tools
 
 - [JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) ![Stars](https://img.shields.io/github/stars/JasonColapietro/suede-creator-skills?style=flat-square)
-  - 71 MIT-licensed skills for Claude Code and Codex
+  - 74 MIT-licensed skills for Claude Code and Codex
   - Covers code review and ship grading, design, marketing, agent workflows, and mobile release preparation
   - Installable through the Claude and Codex plugin marketplaces or the skills CLI
 

--- a/readme.md
+++ b/readme.md
@@ -105,7 +105,7 @@ These repositories offer extensive collections of skills across multiple domains
   - Compatible with 11 different tools
 
 - [JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) ![Stars](https://img.shields.io/github/stars/JasonColapietro/suede-creator-skills?style=flat-square)
-  - 74 MIT-licensed skills for Claude Code and Codex
+  - 74 MIT and BSD-3-Clause licensed skills for Claude Code and Codex
   - Covers code review and ship grading, design, marketing, agent workflows, and mobile release preparation
   - Installable through the Claude and Codex plugin marketplaces or the skills CLI
 

--- a/readme.md
+++ b/readme.md
@@ -105,7 +105,7 @@ These repositories offer extensive collections of skills across multiple domains
   - Compatible with 11 different tools
 
 - [JasonColapietro/suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) ![Stars](https://img.shields.io/github/stars/JasonColapietro/suede-creator-skills?style=flat-square)
-  - 67 MIT-licensed skills for Claude Code and Codex
+  - 71 MIT-licensed skills for Claude Code and Codex
   - Covers code review and ship grading, design, marketing, agent workflows, and mobile release preparation
   - Installable through the Claude and Codex plugin marketplaces or the skills CLI
 


### PR DESCRIPTION
Corrects two stale details on the existing JasonColapietro/suede-creator-skills entry under Comprehensive Skill Collections. One line changed, nothing else touched.

Count: the entry said 67 skills. The repo now ships 74 skills/<name>/SKILL.md folders, and the README badge reads 74.

License: "MIT-licensed" was not accurate for the pack as a whole. The repo declares "MIT AND BSD-3-Clause" in .claude-plugin/plugin.json, and skills/suede-graph-flo-xr ships a BSD-3-Clause notice alongside the MIT LICENSE and NOTICE.md. Most of the pack is MIT; the BSD-3-Clause component is the adapted graph-of-thoughts material.

The other two sub-bullets are still accurate against the live repo, so I left them as they are.
