### PR TITLE
Add ClawMetry to Desktop Applications & GUI Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1152,6 +1152,12 @@ Utilities and tools to enhance your Claude workflow.
 
 ### Desktop Applications & GUI Tools
 
+- [vivekchand/clawmetry](https://github.com/vivekchand/clawmetry) ![Stars](https://img.shields.io/github/stars/vivekchand/clawmetry?style=flat-square)
+  - Local dashboard and kill switch for Claude Code, Codex, Cursor, Gemini CLI, OpenClaw and other coding agents
+  - Reads the session logs the runtimes already write on disk: sessions, transcripts, tool calls, tokens and cache-aware cost; no SDK, nothing in the request path
+  - Opt-in emergency stop per session and pre-tool approvals for risky actions; website at [clawmetry.com](https://clawmetry.com)
+  - Python, MIT, open-core: OpenClaw and NemoClaw free, other runtimes on the Cloud or self-hosted Pro tier
+
 - [CherryHQ/cherry-studio](https://github.com/CherryHQ/cherry-studio) ![Stars](https://img.shields.io/github/stars/CherryHQ/cherry-studio?style=flat-square)
   - AI productivity studio with smart chat and autonomous agents
   - 300+ built-in assistants for various tasks


### PR DESCRIPTION
Adds ClawMetry (https://github.com/vivekchand/clawmetry, website https://clawmetry.com) to Desktop Applications & GUI Tools, matching the entry format (repo link, stars badge, sub-bullets).

What it is: a local dashboard and kill switch for Claude Code, Codex, Cursor, Gemini CLI, OpenClaw and other coding agents. It reads the session logs the runtimes already write on disk, so there is no SDK and nothing in the request path, and shows sessions, transcripts, tool calls, tokens and cache-aware cost. An opt-in emergency stop per session and pre-tool approvals are included. The same setup ships as an Agent Skill: npx skills add vivekchand/clawmetry --skill agent-kill-switch.

Disclosure: I maintain it. Pricing stated in the entry: OpenClaw and NemoClaw are free in the open-source app; the other runtimes need ClawMetry Cloud or a self-hosted Pro license.