### PR TITLE
Add Receipts - evidence gate for coding agents, with the benchmark that tests it

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -442,6 +442,14 @@ Skills focused on software development, code quality, and engineering workflows.
   - Hooks enforce type-checking and lint on edits
   - TypeScript, MIT licensed
 
+- [tainguyen091994/receipts](https://github.com/tainguyen091994/receipts) ![Stars](https://img.shields.io/github/stars/tainguyen091994/receipts?style=flat-square)
+  - Evidence gate: makes an agent paste what it ran before it may claim work is done
+  - Ships a 4-tier benchmark graded by a `pytest` exit code, not by another model
+  - 424 runs, six predictions filed before the data, two of them lost; every transcript committed
+  - Raises evidence rate from 3% to 98%, and is measured *not* to reduce false claims
+  - Adapters for 6 agents from one `SKILL.md`; MIT
+
+
 ### Specialized Agents
 
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) ![Stars](https://img.shields.io/github/stars/VoltAgent/awesome-claude-code-subagents?style=flat-square)


### PR DESCRIPTION
Adds [Receipts](https://github.com/tainguyen091994/receipts) to **Development & Engineering → Core Development Skills**, at the end of the section right before *Specialized Agents*. Matches the surrounding format: repo path, shields.io stars badge, one-line summary followed by nested bullets.

### What it is

A skill that makes a coding agent paste the command output behind a claim — what it ran and what came back — before it may say *done*, *fixed* or *all tests pass*.

### Why it might earn a line here

It ships the benchmark that tests itself, and publishes the half where it fails.

- **424 runs** on `claude-haiku-4-5`, graded by a `pytest` exit code rather than by another model
- **every transcript committed**, so anyone can re-score them without re-running
- **six predictions filed before the data**, one commit each, unedited — **two of them lost** their central bet
- measured effect: **evidence rate 3% → 98%**
- measured non-effect: **it does not reduce false claims.** 75.0% against a 73.6% no-prompt baseline. That is in the README's third section, not a footnote

The harness takes `--agent-cmd`, so it runs against any CLI (`codex`, `gemini`, `ollama`), and results from other models are what the repo most wants.

Six adapters generated from one `SKILL.md` — Claude Code, Cursor, Copilot, Gemini, Windsurf, opencode. MIT.

Happy to shorten the entry, drop bullets, or move it to another section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
