### PR TITLE
Add diffbot/diffbot-skills (Domain-Specific Skills)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,12 @@ These repositories offer extensive collections of skills across multiple domains
   - Contributions from Sentry, Trail of Bits, Expo, DuckDB, Figma, Google
   - Community-driven with regular updates
 
+- [diffbot/diffbot-skills](https://github.com/diffbot/diffbot-skills) ![Stars](https://img.shields.io/github/stars/diffbot/diffbot-skills?style=flat-square)
+  - Official Diffbot collection: 10 production skills for structured web knowledge
+  - Query the Diffbot Knowledge Graph (companies, people, news, places, deals) with DQL
+  - Web extraction, crawling, entity resolution, and web search
+  - MIT-licensed; installs across Claude Code, Cursor, Codex, Copilot, Pi, and more via `npx skills add diffbot/diffbot-skills`
+
 - [sickn33/agentic-awesome-skills](https://github.com/sickn33/agentic-awesome-skills) ![Stars](https://img.shields.io/github/stars/sickn33/agentic-awesome-skills?style=flat-square)
   - 1,326+ installable agentic skills
   - CLI installer for easy setup

--- a/readme.md
+++ b/readme.md
@@ -147,12 +147,6 @@ These repositories offer extensive collections of skills across multiple domains
   - Contributions from Sentry, Trail of Bits, Expo, DuckDB, Figma, Google
   - Community-driven with regular updates
 
-- [diffbot/diffbot-skills](https://github.com/diffbot/diffbot-skills) ![Stars](https://img.shields.io/github/stars/diffbot/diffbot-skills?style=flat-square)
-  - Official Diffbot collection: 10 production skills for structured web knowledge
-  - Query the Diffbot Knowledge Graph (companies, people, news, places, deals) with DQL
-  - Web extraction, crawling, entity resolution, and web search
-  - MIT-licensed; installs across Claude Code, Cursor, Codex, Copilot, Pi, and more via `npx skills add diffbot/diffbot-skills`
-
 - [sickn33/agentic-awesome-skills](https://github.com/sickn33/agentic-awesome-skills) ![Stars](https://img.shields.io/github/stars/sickn33/agentic-awesome-skills?style=flat-square)
   - 1,326+ installable agentic skills
   - CLI installer for easy setup
@@ -939,6 +933,11 @@ Skills for marketing professionals, content creators, and growth teams.
 - [Uhudsavasindankacanokcu2/recruiting-skills-for-claude](https://github.com/Uhudsavasindankacanokcu2/recruiting-skills-for-claude) ![Stars](https://img.shields.io/github/stars/Uhudsavasindankacanokcu2/recruiting-skills-for-claude?style=flat-square) - Job descriptions, bias-aware resume screening & structured interview kits
 
 Specialized skills for specific industries and use cases.
+
+- [diffbot/diffbot-skills](https://github.com/diffbot/diffbot-skills) ![Stars](https://img.shields.io/github/stars/diffbot/diffbot-skills?style=flat-square)
+  - Agent skills for fetching web knowledge as structured data, not AI summaries.
+  - Access web search, Knowledge Graph (companies, people, news, places, deals, and more), extract, and crawl
+  - Compatible with Claude Code, Cursor, Codex, Copilot, Pi, and more via `npx skills add diffbot/diffbot-skills`
 
 - [dhosruiasn/accessible-dark-mode-design-expert](https://github.com/dhosruiasn/accessible-dark-mode-design-expert) ![Stars](https://img.shields.io/github/stars/dhosruiasn/accessible-dark-mode-design-expert?style=flat-square)
   - Accessible light/dark theme design, implementation, review, and audit skill for Claude Code and OpenAI Codex


### PR DESCRIPTION
## What this adds

Adds **diffbot/diffbot-skills** to the **Domain-Specific Skills** section — Diffbot's official, MIT-licensed collection of 10 production skills for structured web knowledge.

## What it is

Diffbot converts unstructured web content into structured, linked facts. These skills give any SKILL.md-compatible agent access to that graph and Diffbot's structuring APIs:

- **diffbot-dql** — query the Diffbot Knowledge Graph directly (companies, people, news, places, deals, products, patents, facets)
- **diffbot-news / -organizations / -people / -places / -deals** — entity-specific searches returning sourced, dated rows
- **diffbot-extract** — scrape/parse any URL into markdown or structured data
- **diffbot-crawl** — create/manage crawl jobs
- **diffbot-entities** — NER + entity linking via the Diffbot NLP API
- **diffbot-web-search** — ranked web/document research with relevance scores

## Fit with the contribution checklist

- **Actively maintained** — repo is live and iterating (v1.1.1); skills share a single source of truth.
- **Clear documentation** — full README with install paths per harness (Claude Code plugin marketplace, `npx skills`), plus `docs/CLAUDE.md`.
- **Real value to Claude users** — converts Diffbot's trillion-fact Knowledge Graph into model-invocable capabilities; cross-agent (Claude Code, Cursor, Codex, GitHub Copilot, Pi, Factory, Snowflake Cortex Code, and more).
- **Open standard** — all 10 skills are plain `SKILL.md` folders under `skills/`, no proprietary runtime.

## Install

```bash
npx skills add diffbot/diffbot-skills
# or the Claude Code marketplace
/plugin marketplace add diffbot/diffbot-skills
```

## Files changed

`readme.md` — one new entry in **Domain-Specific Skills**, matching the existing nested format.