### PR TITLE
Add trace-mcp to MCP Servers & Integrations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1532,6 +1532,13 @@ Utilities and tools to enhance your Claude workflow.
   - Query databases and create/update pages and blocks via the Notion API
   - Supports a hosted remote endpoint and local stdio deployment
 
+- [nikolai-vysotskyi/trace-mcp](https://github.com/nikolai-vysotskyi/trace-mcp) ![Stars](https://img.shields.io/github/stars/nikolai-vysotskyi/trace-mcp?style=flat-square)
+  - Indexes a repository once, then answers with symbols, call graphs and change impact instead of file reads
+  - Outline and single-symbol lookups replace re-reading whole files turn after turn
+  - 81 languages and 87 framework integrations; runs entirely local, no API key
+  - Median 90.6% fewer input tokens to assemble PR-review context, measured over 60 merged PRs in 6 repos that are not ours ([method](https://trace-mcp.com/pr-context-benchmark.html))
+  - TypeScript, MIT licensed
+
 ### API & Integration Tools
 
 - [router-for-me/CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) ![Stars](https://img.shields.io/github/stars/router-for-me/CLIProxyAPI?style=flat-square)


### PR DESCRIPTION
Disclosure: I maintain trace-mcp, so this is a self-submission rather than a third-party recommendation.

Adds trace-mcp to the end of **Productivity Tools → MCP Servers & Integrations**, in the slot `oraios/serena` opens: same problem, opposite approach. Serena resolves symbols on demand through a language server; trace-mcp precomputes the whole map at index time, so a lookup is a read from an index rather than an LSP round trip.

It is a local MCP server that indexes a repo once and then answers "where is this symbol", "who calls it", "what breaks if I change it" from that index, instead of the agent re-reading the same files every turn. TypeScript, MIT, no API key, nothing leaves the machine.

One note on the number in the entry. The 90.6% is measured, not estimated: 60 merged PRs across 6 repos that aren't mine, input tokens for naive file loading vs. trace-mcp context, with the harness and the raw per-PR data on the linked page. If you'd rather keep figures out of list entries, drop that bullet — the entry stands without it.

Against the four rules in Contributing: last release was today (v3.19.0, ~4 releases a week), docs at trace-mcp.com. The diff is 7 lines and touches nothing else; `Contents` links to sections, so it needs no edit.

