### PR TITLE
Add Orkas to Desktop Applications & GUI Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1203,6 +1203,10 @@ Utilities and tools to enhance your Claude workflow.
   - Turns CLI-based AI orchestration into a desktop experience
   - TypeScript-driven Electron build
 
+- [Orkas-AI/Orkas](https://github.com/Orkas-AI/Orkas)
+  - Open-source, local-first desktop AI workforce coordinated by a Commander through one chat.
+  - Coordinates built-in specialist agents and local coding agents, including Claude Code and Codex
+
 ### Agent Harnesses & Meta-Tools
 
 - [code-yeongyu/oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) ![Stars](https://img.shields.io/github/stars/code-yeongyu/oh-my-openagent?style=flat-square)


### PR DESCRIPTION
Adds Orkas to Desktop Applications & GUI Tools with a concise entry matching the current project documentation.

Checked the destination format, public project link, duplicate PRs/issues, and `git diff --check`.

Disclosure: submitted on behalf of the Orkas project.
