### PR TITLE
Add OrcaReplay to Core Development Skills

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -442,6 +442,12 @@ Skills focused on software development, code quality, and engineering workflows.
   - Hooks enforce type-checking and lint on edits
   - TypeScript, MIT licensed
 
+- [Continuum-AI-Corp/OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) ![Stars](https://img.shields.io/github/stars/Continuum-AI-Corp/OrcaReplay?style=flat-square)
+  - Answers "why did the earlier run do that" from a recording instead of from memory
+  - Records below the harness: model traffic, shell exit codes, per-turn file changes and MCP calls on one timeline
+  - Replays a run offline byte-for-byte with the network off, or forks it from a checkpoint onto a different model
+  - Ships an MCP server (6 tools) plus a SKILL.md; works with Claude Code, Codex, opencode, Qwen Code and Cursor
+
 ### Specialized Agents
 
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) ![Stars](https://img.shields.io/github/stars/VoltAgent/awesome-claude-code-subagents?style=flat-square)


### PR DESCRIPTION
Adds OrcaReplay to **Development & Engineering → Core Development Skills**.

**What it does.** It makes an earlier agent run answerable. Capture happens below the harness, at the process and socket boundary, so the model traffic, the shell commands with their exit codes, the per-turn file changes and the MCP JSON-RPC calls all land on one timeline. The recording then replays offline — recorded responses served back with the network off, so the run reproduces byte-for-byte on another machine — or forks from any checkpoint onto a different model.

The skill (`skills/orca-replay/SKILL.md` in the repo) is the part that matters for this list: it tells an agent to read the trace rather than reconstruct events from context, and to distinguish what the recording actually shows from what it is inferring.

**Against your four criteria**

1. *Actively maintained* — 0.2.1 published this week; last commit today.
2. *Clear documentation* — README, a validation write-up of a real bug fix recorded, replayed offline end to end and forked, and RELEASING.md.
3. *Real value to Claude users* — Claude Code is the primary validated target.
4. *Clear description* — above.

**Production-ready, with the caveat stated.** 12 packages on npm with sigstore provenance, Apache-2.0, CI green, and the same skill was reviewed and merged into sickn33/agentic-awesome-skills and published to ClawHub after its security scan. The honest counterweight: the repository is nine days old and npm adoption is still near zero. If "production-ready over experimental" means you want to see usage first, that is a fair reason to hold this.
