### PR TITLE
Add Slashskills to skill collections

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -279,6 +279,11 @@ These repositories offer extensive collections of skills across multiple domains
   - Also personal analytics and Claude Code operations
   - Each skill is a self-contained SKILL.md folder; installable via plugin marketplace or `npx skills add`
 
+- [tushaarmehtaa/tushar-skills](https://github.com/tushaarmehtaa/tushar-skills) ![Stars](https://img.shields.io/github/stars/tushaarmehtaa/tushar-skills?style=flat-square)
+  - MIT-licensed Agent Skills for software design, implementation, release checks, and documentation
+  - Per-runtime installation guidance for Claude Code, Codex, and Cursor
+  - Explicit tool requirements and bundled Markdown references
+
 ## Development & Engineering
 
 Skills focused on software development, code quality, and engineering workflows.


### PR DESCRIPTION
Add Slashskills to Comprehensive Skill Collections. The repository supplies directly installable SKILL.md workflows for software work, with bundled references and runtime-specific installation documentation.

Only the collection listing is added; no generated counts or adoption claims.
Affiliation: I maintain tushaarmehtaa/tushar-skills. Prepared with AI assistance.

The source is MIT-licensed. Installation and runtime/tool requirements are documented. Repository/package validation and site tests pass; these are not claims of end-to-end Claude runtime testing or community adoption.

Searched existing README entries, issues, and PRs for duplicates.
